### PR TITLE
Mettre en avant les six expertises RenoGo sur la page d’accueil

### DIFF
--- a/index.html
+++ b/index.html
@@ -288,33 +288,63 @@
   <div class="container">
     <div class="row">
 
-      <!-- Bloc 1 -->
-      <div class="col-lg-4">
+      <!-- Jardin & Paysage -->
+      <div class="col-lg-4 col-md-6">
         <div class="icon-content">
-          <figure><img src="images/icon01.png" alt="Jardin et aménagement paysager"></figure>
+          <figure><img src="images/icon01.png" alt="Paysagiste et jardinier RenoGo en Normandie"></figure>
           <h3>Jardin & Paysage</h3>
-          <small>Création et entretien de jardins en Normandie : pelouses, massifs, terrasses et espaces verts qui subliment votre maison.</small> 
-          <a href="services.html#jardin">+</a>
+          <small>Massifs fleuris, terrasses bois et entretien quatre saisons : nous sculptons des jardins normands généreux qui mettent en scène votre maison.</small>
+          <a href="services.html#tab01">+</a>
         </div>
       </div>
 
-      <!-- Bloc 2 -->
-      <div class="col-lg-4">
+      <!-- Electricite -->
+      <div class="col-lg-4 col-md-6">
         <div class="icon-content">
-          <figure><img src="images/icon02.png" alt="Électricité et domotique"></figure>
-          <h3>Électricité & Maison intelligente</h3>
-          <small>Installation électrique, éclairage moderne et solutions domotiques pour plus de sécurité, d’économie et de confort au quotidien.</small> 
-          <a href="services.html#electricite">+</a>
+          <figure><img src="images/icon02.png" alt="Électricien certifié en mise aux normes à Rouen et Caen"></figure>
+          <h3>Électricité</h3>
+          <small>Tableaux neufs, éclairages LED et sécurité renforcée : nos électriciens certifiés sécurisent vos chantiers du littoral au pays d’Auge.</small>
+          <a href="services.html#tab02">+</a>
         </div>
       </div>
 
-      <!-- Bloc 3 -->
-      <div class="col-lg-4">
+      <!-- Maison Connecte -->
+      <div class="col-lg-4 col-md-6">
         <div class="icon-content">
-          <figure><img src="images/icon03.png" alt="Peinture et rénovation intérieure"></figure>
-          <h3>Peinture, sols & isolation</h3>
-          <small>Peinture de qualité, pose de parquet ou PVC, cloisons et isolation thermique pour embellir et améliorer votre habitat.</small> 
-          <a href="services.html#peinture">+</a>
+          <figure><img src="images/icon06.png" alt="Solutions de maison connectée et domotique en Normandie"></figure>
+          <h3>Maison Connectée</h3>
+          <small>Pilotage à distance, scénarios lumière et chauffage intelligent : RenoGo transforme votre demeure normande en maison connectée intuitive.</small>
+          <a href="services.html#services-electricite">+</a>
+        </div>
+      </div>
+
+      <!-- Peinture -->
+      <div class="col-lg-4 col-md-6">
+        <div class="icon-content">
+          <figure><img src="images/icon03.png" alt="Peintres RenoGo réalisant des finitions haut de gamme"></figure>
+          <h3>Peinture</h3>
+          <small>Finitions veloutées, teintes minérales inspirées des falaises d’Étretat et protections durables pour sublimer murs et boiseries.</small>
+          <a href="services.html#tab03">+</a>
+        </div>
+      </div>
+
+      <!-- Mur & Sol -->
+      <div class="col-lg-4 col-md-6">
+        <div class="icon-content">
+          <figure><img src="images/icon05.png" alt="Pose de cloisons sèches et revêtements de sol RenoGo"></figure>
+          <h3>Mur & Sol</h3>
+          <small>Cloisons légères, parquet chêne de Normandie ou carrelage grand format : nous structurons et habillons vos volumes avec élégance.</small>
+          <a href="services.html#tab05">+</a>
+        </div>
+      </div>
+
+      <!-- Isolation -->
+      <div class="col-lg-4 col-md-6">
+        <div class="icon-content">
+          <figure><img src="images/icon04.png" alt="Isolation thermique et acoustique pour maisons normandes"></figure>
+          <h3>Isolation</h3>
+          <small>Laine de bois, ouate et solutions biosourcées : optimisez votre confort thermique et acoustique tout en valorisant votre bâti.</small>
+          <a href="services.html#tab04">+</a>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- enrichi la section services de la page d’accueil avec six cartes dédiées couvrant l’ensemble du portefeuille RenoGo
- optimisé le micro-copy pour évoquer les spécificités normandes et renforcer l’impact SEO local
- ajusté les liens vers les sections détaillées des services pour favoriser la navigation

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d16b6ed864832ea169acf2299b9c2b