### PR TITLE
Harden support link attributes and tidy mobile menu markup

### DIFF
--- a/about-company.html
+++ b/about-company.html
@@ -174,11 +174,12 @@
       <nav class="site-menu" aria-label="Menu principal mobile">
         <ul>
           <li class="has-children">
-         <a href="about-company.html">À propos</a></a>
+         <a href="about-company.html">À propos</a>
           </li>
           <li><a href="services.html">Services</a></li>
           <li><a href="projects.html">Projets</a></li>
           <li><a href="news.html">Actualités</a></li>
+          <li><a href="https://renogo.atlassian.net/servicedesk/customer/portal/2" target="_blank" rel="noopener noreferrer">Support</a></li>
           <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
@@ -207,6 +208,7 @@
         <li><a href="services.html">Services</a></li>
         <li><a href="projects.html">Projets</a></li>
         <li><a href="news.html">Actualités</a></li>
+        <li><a href="https://renogo.atlassian.net/servicedesk/customer/portal/2" target="_blank" rel="noopener noreferrer">Support</a></li>
         <li><a href="contact.html">Contact</a></li>
       </ul>
     </div>

--- a/certificates.html
+++ b/certificates.html
@@ -98,6 +98,7 @@ Geneva Switzerland</p>
         <li><a href="services.html">Services</a></li>
         <li><a href="projects.html">Projects</a></li>
         <li><a href="news.html">News</a></li>
+        <li><a href="https://renogo.atlassian.net/servicedesk/customer/portal/2" target="_blank" rel="noopener noreferrer">Support</a></li>
         <li><a href="contact.html">Contact</a></li>
       </ul>
     </div>
@@ -135,6 +136,7 @@ Geneva Switzerland</p>
         <li><a href="services.html">Services</a></li>
         <li><a href="projects.html">Projects</a></li>
         <li><a href="news.html">News</a></li>
+        <li><a href="https://renogo.atlassian.net/servicedesk/customer/portal/2" target="_blank" rel="noopener noreferrer">Support</a></li>
         <li><a href="contact.html">Contact</a></li>
       </ul>
     </div>

--- a/contact.html
+++ b/contact.html
@@ -174,11 +174,12 @@
       <nav class="site-menu" aria-label="Menu principal mobile">
         <ul>
           <li class="has-children">
-         <a href="about-company.html">À propos</a></a>
+         <a href="about-company.html">À propos</a>
           </li>
           <li><a href="services.html">Services</a></li>
           <li><a href="projects.html">Projets</a></li>
           <li><a href="news.html">Actualités</a></li>
+          <li><a href="https://renogo.atlassian.net/servicedesk/customer/portal/2" target="_blank" rel="noopener noreferrer">Support</a></li>
           <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
@@ -207,6 +208,7 @@
         <li><a href="services.html">Services</a></li>
         <li><a href="projects.html">Projets</a></li>
         <li><a href="news.html">Actualités</a></li>
+        <li><a href="https://renogo.atlassian.net/servicedesk/customer/portal/2" target="_blank" rel="noopener noreferrer">Support</a></li>
         <li><a href="contact.html">Contact</a></li>
       </ul>
     </div>

--- a/core-values.html
+++ b/core-values.html
@@ -98,6 +98,7 @@ Geneva Switzerland</p>
         <li><a href="services.html">Services</a></li>
         <li><a href="projects.html">Projects</a></li>
         <li><a href="news.html">News</a></li>
+        <li><a href="https://renogo.atlassian.net/servicedesk/customer/portal/2" target="_blank" rel="noopener noreferrer">Support</a></li>
         <li><a href="contact.html">Contact</a></li>
       </ul>
     </div>
@@ -135,6 +136,7 @@ Geneva Switzerland</p>
         <li><a href="services.html">Services</a></li>
         <li><a href="projects.html">Projects</a></li>
         <li><a href="news.html">News</a></li>
+        <li><a href="https://renogo.atlassian.net/servicedesk/customer/portal/2" target="_blank" rel="noopener noreferrer">Support</a></li>
         <li><a href="contact.html">Contact</a></li>
       </ul>
     </div>

--- a/index.html
+++ b/index.html
@@ -174,11 +174,12 @@
       <nav class="site-menu" aria-label="Menu principal mobile">
         <ul>
           <li class="has-children">
-         <a href="about-company.html">À propos</a></a>
+         <a href="about-company.html">À propos</a>
           </li>
           <li><a href="services.html">Services</a></li>
           <li><a href="projects.html">Projets</a></li>
           <li><a href="news.html">Actualités</a></li>
+          <li><a href="https://renogo.atlassian.net/servicedesk/customer/portal/2" target="_blank" rel="noopener noreferrer">Support</a></li>
           <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
@@ -207,6 +208,7 @@
         <li><a href="services.html">Services</a></li>
         <li><a href="projects.html">Projets</a></li>
         <li><a href="news.html">Actualités</a></li>
+        <li><a href="https://renogo.atlassian.net/servicedesk/customer/portal/2" target="_blank" rel="noopener noreferrer">Support</a></li>
         <li><a href="contact.html">Contact</a></li>
       </ul>
     </div>

--- a/leadership.html
+++ b/leadership.html
@@ -98,6 +98,7 @@ Geneva Switzerland</p>
         <li><a href="services.html">Services</a></li>
         <li><a href="projects.html">Projects</a></li>
         <li><a href="news.html">News</a></li>
+        <li><a href="https://renogo.atlassian.net/servicedesk/customer/portal/2" target="_blank" rel="noopener noreferrer">Support</a></li>
         <li><a href="contact.html">Contact</a></li>
       </ul>
     </div>
@@ -135,6 +136,7 @@ Geneva Switzerland</p>
         <li><a href="services.html">Services</a></li>
         <li><a href="projects.html">Projects</a></li>
         <li><a href="news.html">News</a></li>
+        <li><a href="https://renogo.atlassian.net/servicedesk/customer/portal/2" target="_blank" rel="noopener noreferrer">Support</a></li>
         <li><a href="contact.html">Contact</a></li>
       </ul>
     </div>

--- a/news-sing.html
+++ b/news-sing.html
@@ -98,6 +98,7 @@ Geneva Switzerland</p>
         <li><a href="services.html">Services</a></li>
         <li><a href="projects.html">Projects</a></li>
         <li><a href="news.html">News</a></li>
+        <li><a href="https://renogo.atlassian.net/servicedesk/customer/portal/2" target="_blank" rel="noopener noreferrer">Support</a></li>
         <li><a href="contact.html">Contact</a></li>
       </ul>
     </div>
@@ -135,6 +136,7 @@ Geneva Switzerland</p>
         <li><a href="services.html">Services</a></li>
         <li><a href="projects.html">Projects</a></li>
         <li><a href="news.html">News</a></li>
+        <li><a href="https://renogo.atlassian.net/servicedesk/customer/portal/2" target="_blank" rel="noopener noreferrer">Support</a></li>
         <li><a href="contact.html">Contact</a></li>
       </ul>
     </div>

--- a/news.html
+++ b/news.html
@@ -174,11 +174,12 @@
       <nav class="site-menu" aria-label="Menu principal mobile">
         <ul>
           <li class="has-children">
-         <a href="about-company.html">À propos</a></a>
+         <a href="about-company.html">À propos</a>
           </li>
           <li><a href="services.html">Services</a></li>
           <li><a href="projects.html">Projets</a></li>
           <li><a href="news.html">Actualités</a></li>
+          <li><a href="https://renogo.atlassian.net/servicedesk/customer/portal/2" target="_blank" rel="noopener noreferrer">Support</a></li>
           <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
@@ -205,6 +206,7 @@
         <li><a href="services.html">Services</a></li>
         <li><a href="projects.html">Projets</a></li>
         <li><a href="news.html">Actualités</a></li>
+        <li><a href="https://renogo.atlassian.net/servicedesk/customer/portal/2" target="_blank" rel="noopener noreferrer">Support</a></li>
         <li><a href="contact.html">Contact</a></li>
       </ul>
     </div>

--- a/offices.html
+++ b/offices.html
@@ -98,6 +98,7 @@ Geneva Switzerland</p>
         <li><a href="services.html">Services</a></li>
         <li><a href="projects.html">Projects</a></li>
         <li><a href="news.html">News</a></li>
+        <li><a href="https://renogo.atlassian.net/servicedesk/customer/portal/2" target="_blank" rel="noopener noreferrer">Support</a></li>
         <li><a href="contact.html">Contact</a></li>
       </ul>
     </div>
@@ -135,6 +136,7 @@ Geneva Switzerland</p>
         <li><a href="services.html">Services</a></li>
         <li><a href="projects.html">Projects</a></li>
         <li><a href="news.html">News</a></li>
+        <li><a href="https://renogo.atlassian.net/servicedesk/customer/portal/2" target="_blank" rel="noopener noreferrer">Support</a></li>
         <li><a href="contact.html">Contact</a></li>
       </ul>
     </div>

--- a/our-history.html
+++ b/our-history.html
@@ -98,6 +98,7 @@ Geneva Switzerland</p>
         <li><a href="services.html">Services</a></li>
         <li><a href="projects.html">Projects</a></li>
         <li><a href="news.html">News</a></li>
+        <li><a href="https://renogo.atlassian.net/servicedesk/customer/portal/2" target="_blank" rel="noopener noreferrer">Support</a></li>
         <li><a href="contact.html">Contact</a></li>
       </ul>
     </div>
@@ -135,6 +136,7 @@ Geneva Switzerland</p>
         <li><a href="services.html">Services</a></li>
         <li><a href="projects.html">Projects</a></li>
         <li><a href="news.html">News</a></li>
+        <li><a href="https://renogo.atlassian.net/servicedesk/customer/portal/2" target="_blank" rel="noopener noreferrer">Support</a></li>
         <li><a href="contact.html">Contact</a></li>
       </ul>
     </div>

--- a/project-single.html
+++ b/project-single.html
@@ -98,6 +98,7 @@ Geneva Switzerland</p>
         <li><a href="services.html">Services</a></li>
         <li><a href="projects.html">Projects</a></li>
         <li><a href="news.html">News</a></li>
+        <li><a href="https://renogo.atlassian.net/servicedesk/customer/portal/2" target="_blank" rel="noopener noreferrer">Support</a></li>
         <li><a href="contact.html">Contact</a></li>
       </ul>
     </div>
@@ -135,6 +136,7 @@ Geneva Switzerland</p>
         <li><a href="services.html">Services</a></li>
         <li><a href="projects.html">Projects</a></li>
         <li><a href="news.html">News</a></li>
+        <li><a href="https://renogo.atlassian.net/servicedesk/customer/portal/2" target="_blank" rel="noopener noreferrer">Support</a></li>
         <li><a href="contact.html">Contact</a></li>
       </ul>
     </div>

--- a/projects.html
+++ b/projects.html
@@ -174,11 +174,12 @@
       <nav class="site-menu" aria-label="Menu principal mobile">
         <ul>
           <li class="has-children">
-         <a href="about-company.html">À propos</a></a>
+         <a href="about-company.html">À propos</a>
           </li>
           <li><a href="services.html">Services</a></li>
           <li><a href="projects.html">Projets</a></li>
           <li><a href="news.html">Actualités</a></li>
+          <li><a href="https://renogo.atlassian.net/servicedesk/customer/portal/2" target="_blank" rel="noopener noreferrer">Support</a></li>
           <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
@@ -207,6 +208,7 @@
         <li><a href="services.html">Services</a></li>
         <li><a href="projects.html">Projets</a></li>
         <li><a href="news.html">Actualités</a></li>
+        <li><a href="https://renogo.atlassian.net/servicedesk/customer/portal/2" target="_blank" rel="noopener noreferrer">Support</a></li>
         <li><a href="contact.html">Contact</a></li>
       </ul>
     </div>

--- a/services.html
+++ b/services.html
@@ -174,11 +174,12 @@
       <nav class="site-menu" aria-label="Menu principal mobile">
         <ul>
           <li class="has-children">
-         <a href="about-company.html">À propos</a></a>
+         <a href="about-company.html">À propos</a>
           </li>
           <li><a href="services.html">Services</a></li>
           <li><a href="projects.html">Projets</a></li>
           <li><a href="news.html">Actualités</a></li>
+          <li><a href="https://renogo.atlassian.net/servicedesk/customer/portal/2" target="_blank" rel="noopener noreferrer">Support</a></li>
           <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
@@ -207,6 +208,7 @@
         <li><a href="services.html">Services</a></li>
         <li><a href="projects.html">Projets</a></li>
         <li><a href="news.html">Actualités</a></li>
+        <li><a href="https://renogo.atlassian.net/servicedesk/customer/portal/2" target="_blank" rel="noopener noreferrer">Support</a></li>
         <li><a href="contact.html">Contact</a></li>
       </ul>
     </div>


### PR DESCRIPTION
## Summary
- add `rel="noopener noreferrer"` to every Support navigation link across the desktop and mobile menus for safer new-tab behavior
- remove the duplicated closing anchor tag in the French mobile drawer menus to keep the markup valid and avoid merge conflicts

## Testing
- not run (static HTML changes)


------
https://chatgpt.com/codex/tasks/task_e_68d17b7b8d64832ebcc2599d93ab7f9b