### PR TITLE
Refine service highlights and responsive styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1264,6 +1264,104 @@ a:hover {
   text-decoration: none;
 }
 
+.service-highlight {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  height: 100%;
+  background: #fff;
+  border: 1px solid #e8e8e8;
+  border-radius: 18px;
+  padding: 45px 35px 40px;
+  box-shadow: 0 25px 35px rgba(15, 15, 15, 0.06);
+  transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
+}
+
+.service-highlight:hover,
+.service-highlight:focus-within {
+  transform: translateY(-8px);
+  border-color: #ff7a04;
+  box-shadow: 0 35px 50px rgba(15, 15, 15, 0.12);
+}
+
+.service-highlight__icon {
+  width: 96px;
+  height: 96px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: #ff7a04;
+  margin-bottom: 32px;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.service-highlight__icon img {
+  max-width: 48px;
+  height: auto;
+}
+
+.service-highlight:hover .service-highlight__icon,
+.service-highlight:focus-within .service-highlight__icon {
+  transform: scale(1.08) rotate(-2deg);
+  box-shadow: 0 18px 30px rgba(255, 122, 4, 0.38);
+}
+
+.service-highlight h3 {
+  margin-bottom: 22px;
+}
+
+.service-highlight p {
+  flex-grow: 1;
+  font-size: 17px;
+  line-height: 1.65;
+  color: #555;
+  margin-bottom: 30px;
+}
+
+.service-highlight__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 13px;
+  color: #0b0b0b;
+  transition: color 0.3s ease;
+}
+
+.service-highlight__link:after {
+  content: "\2192";
+  font-size: 16px;
+  transition: transform 0.3s ease;
+}
+
+.service-highlight__link:hover,
+.service-highlight__link:focus {
+  color: #ff7a04;
+  text-decoration: none;
+}
+
+.service-highlight__link:hover:after,
+.service-highlight__link:focus:after {
+  transform: translateX(4px);
+}
+
+@keyframes servicePulse {
+  0%,
+  100% {
+    transform: scale(1);
+    box-shadow: 0 0 0 0 rgba(255, 122, 4, 0.45);
+  }
+
+  50% {
+    transform: scale(1.08);
+    box-shadow: 0 0 0 14px rgba(255, 122, 4, 0);
+  }
+}
+
 /* SIDE IMAGE */
 .side-image {
   width: 100%;
@@ -3384,6 +3482,10 @@ input::-moz-focus-inner, input::-moz-focus-outer {
   .footer-bar h2 {
     padding: 0;
   }
+
+  .service-highlight {
+    padding: 40px 30px 35px;
+  }
 }
 /* RESPONSIVE TABLET  */
 @media only screen and (max-width: 991px), only screen and (max-device-width: 991px) {
@@ -3413,6 +3515,20 @@ input::-moz-focus-inner, input::-moz-focus-outer {
 
   .counter-box .value {
     margin-right: 20px;
+  }
+
+  .service-highlight {
+    margin: 15px 0;
+    padding: 35px 28px 32px;
+  }
+
+  .service-highlight__icon {
+    width: 88px;
+    height: 88px;
+  }
+
+  .service-highlight p {
+    font-size: 16px;
   }
 
   .step-box {
@@ -3642,6 +3758,41 @@ input::-moz-focus-inner, input::-moz-focus-outer {
 
   .icon-content small {
     margin-bottom: 30px;
+  }
+
+  .service-highlight {
+    align-items: center;
+    text-align: center;
+    background: transparent;
+    border: none;
+    box-shadow: none;
+    padding: 0;
+    margin: 20px auto;
+    max-width: 220px;
+  }
+
+  .service-highlight:hover,
+  .service-highlight:focus-within {
+    transform: none;
+    box-shadow: none;
+  }
+
+  .service-highlight__icon {
+    width: 84px;
+    height: 84px;
+    margin-bottom: 12px;
+    box-shadow: 0 18px 40px rgba(255, 122, 4, 0.35);
+    animation: servicePulse 4s ease-in-out infinite;
+  }
+
+  .service-highlight h3 {
+    margin-bottom: 0;
+    font-size: 20px;
+  }
+
+  .service-highlight p,
+  .service-highlight__link {
+    display: none;
   }
 
   .project-slider .swiper-slide .project-box figcaption {

--- a/index.html
+++ b/index.html
@@ -292,62 +292,74 @@
 
       <!-- Jardin & Paysage -->
       <div class="col-lg-4 col-md-6">
-        <div class="icon-content">
-          <figure><img src="images/icon01.png" alt="Paysagiste et jardinier RenoGo en Normandie"></figure>
-          <h3>Jardin & Paysage</h3>
-          <small>Massifs fleuris, terrasses bois et entretien quatre saisons : nous sculptons des jardins normands généreux qui mettent en scène votre maison.</small>
-          <a href="services.html#tab01">+</a>
-        </div>
+        <article class="service-highlight">
+          <figure class="service-highlight__icon">
+            <img src="images/icon01.png" alt="Création de jardins et paysagisme RenoGo en Normandie">
+          </figure>
+          <h3>Jardin &amp; Paysage</h3>
+          <p>Entre Rouen, Caen et le littoral, nos jardiniers sculptent massifs, terrasses et potagers productifs pour un extérieur qui respire la côte normande toute l’année.</p>
+          <a class="service-highlight__link" href="services.html#tab01">Découvrir le service</a>
+        </article>
       </div>
 
-      <!-- Electricite -->
+      <!-- Electricité -->
       <div class="col-lg-4 col-md-6">
-        <div class="icon-content">
-          <figure><img src="images/icon02.png" alt="Électricien certifié en mise aux normes à Rouen et Caen"></figure>
+        <article class="service-highlight">
+          <figure class="service-highlight__icon">
+            <img src="images/icon02.png" alt="Mise aux normes électriques RenoGo en Normandie">
+          </figure>
           <h3>Électricité</h3>
-          <small>Tableaux neufs, éclairages LED et sécurité renforcée : nos électriciens certifiés sécurisent vos chantiers du littoral au pays d’Auge.</small>
-          <a href="services.html#tab02">+</a>
-        </div>
+          <p>Tableaux conformes NF C 15-100, éclairage basse conso et prises extérieures étanches : nous sécurisons votre habitat normand et réduisons vos factures.</p>
+          <a class="service-highlight__link" href="services.html#tab02">Découvrir le service</a>
+        </article>
       </div>
 
-      <!-- Maison Connecte -->
+      <!-- Maison Connectée -->
       <div class="col-lg-4 col-md-6">
-        <div class="icon-content">
-          <figure><img src="images/icon06.png" alt="Solutions de maison connectée et domotique en Normandie"></figure>
+        <article class="service-highlight">
+          <figure class="service-highlight__icon">
+            <img src="images/icon09.png" alt="Solutions de maison connectée RenoGo">
+          </figure>
           <h3>Maison Connectée</h3>
-          <small>Pilotage à distance, scénarios lumière et chauffage intelligent : RenoGo transforme votre demeure normande en maison connectée intuitive.</small>
-          <a href="services.html#services-electricite">+</a>
-        </div>
+          <p>Scénarios domotiques, pilotage du chauffage face à l’humidité marine et sécurité à distance : votre maison normande devient intelligente et sereine.</p>
+          <a class="service-highlight__link" href="services.html#services-electricite">Découvrir le service</a>
+        </article>
       </div>
 
       <!-- Peinture -->
       <div class="col-lg-4 col-md-6">
-        <div class="icon-content">
-          <figure><img src="images/icon03.png" alt="Peintres RenoGo réalisant des finitions haut de gamme"></figure>
+        <article class="service-highlight">
+          <figure class="service-highlight__icon">
+            <img src="images/icon03.png" alt="Peinture intérieure RenoGo en Normandie">
+          </figure>
           <h3>Peinture</h3>
-          <small>Finitions veloutées, teintes minérales inspirées des falaises d’Étretat et protections durables pour sublimer murs et boiseries.</small>
-          <a href="services.html#tab03">+</a>
-        </div>
+          <p>Finitions satinées résistantes au sel, effets chaux pour les demeures de caractère : nos peintres redonnent éclat et lumière aux intérieurs normands.</p>
+          <a class="service-highlight__link" href="services.html#tab03">Découvrir le service</a>
+        </article>
       </div>
 
       <!-- Mur & Sol -->
       <div class="col-lg-4 col-md-6">
-        <div class="icon-content">
-          <figure><img src="images/icon05.png" alt="Pose de cloisons sèches et revêtements de sol RenoGo"></figure>
-          <h3>Mur & Sol</h3>
-          <small>Cloisons légères, parquet chêne de Normandie ou carrelage grand format : nous structurons et habillons vos volumes avec élégance.</small>
-          <a href="services.html#tab05">+</a>
-        </div>
+        <article class="service-highlight">
+          <figure class="service-highlight__icon">
+            <img src="images/icon05.png" alt="Revêtements muraux et sols RenoGo">
+          </figure>
+          <h3>Mur &amp; Sol</h3>
+          <p>Pose de plaques de plâtre, carrelage grand format ou parquet chaleureux : nos équipes harmonisent vos volumes et créent des circulations fluides.</p>
+          <a class="service-highlight__link" href="services.html#tab05">Découvrir le service</a>
+        </article>
       </div>
 
       <!-- Isolation -->
       <div class="col-lg-4 col-md-6">
-        <div class="icon-content">
-          <figure><img src="images/icon04.png" alt="Isolation thermique et acoustique pour maisons normandes"></figure>
+        <article class="service-highlight">
+          <figure class="service-highlight__icon">
+            <img src="images/icon06.png" alt="Isolation thermique et acoustique RenoGo">
+          </figure>
           <h3>Isolation</h3>
-          <small>Laine de bois, ouate et solutions biosourcées : optimisez votre confort thermique et acoustique tout en valorisant votre bâti.</small>
-          <a href="services.html#tab04">+</a>
-        </div>
+          <p>Isolation des combles, doublages biosourcés ou correction acoustique des pièces à vivre : nous protégeons votre maison normande des vents et de l’humidité.</p>
+          <a class="service-highlight__link" href="services.html#tab04">Découvrir le service</a>
+        </article>
       </div>
 
     </div>


### PR DESCRIPTION
## Summary
- replace the home page service grid with six SEO-focused storytelling cards covering the full RenoGo offer
- introduce the new `service-highlight` component with CTA styling and engaging hover motion
- tailor responsive rules so the mobile view keeps only animated orange icons and subtitles for faster scanning

## Testing
- not run (static site changes)


------
https://chatgpt.com/codex/tasks/task_e_68d1aa383a94832ebfbd5ebccb6d4a32