### PR TITLE
Update RenoGo address to new Paris headquarters

### DIFF
--- a/about-company.html
+++ b/about-company.html
@@ -82,9 +82,11 @@
     "foundingDate": "2025",
     "address": {
       "@type": "PostalAddress",
-      "addressCountry": "FR",
-      "addressRegion": "Normandie",
-      "addressLocality": "Eure"
+      "streetAddress": "59, rue de Ponthieu, Bureau 326",
+      "postalCode": "75008",
+      "addressLocality": "Paris",
+      "addressRegion": "Île-de-France",
+      "addressCountry": "FR"
     },
     "sameAs": [
       "https://www.linkedin.com/company/renogo",
@@ -155,7 +157,8 @@
 
       <h6 class="widget-title">ADRESSE</h6>
       <address class="address">
-        <p>Paris (Île-de-France) — Coordination des projets<br>
+        <p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
+        <p>Coordination des projets en Île-de-France<br>
            Interventions en Normandie (Rouen, Caen, Évreux…)</p>
         <p>+33 2 32 00 00 05</p>
       </address>
@@ -630,19 +633,18 @@
     <div class="row">
       <div class="col-lg-4 col-md-6">
         <h6 class="widget-title">SIÈGE SOCIAL</h6>
-        <address><p>24 rue de l'Innovation<br>
-75011 Paris</p>
+        <address><p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
                   <p>+33 (0)1 86 76 90 12</p>
-                        <a href="https://www.google.com/maps/search/?api=1&query=24+rue+de+l'Innovation+75011+Paris" data-fancybox data-width="640" data-height="360">NOUS LOCALISER</a>
+                        <a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">NOUS LOCALISER</a>
                         </address>
       </div>
       <!-- end col-4 -->
                 <div class="col-lg-4 col-md-6">
         <h6 class="widget-title">AGENCE NORMANDIE</h6>
-        <address><p>12 place Saint-Marc<br>
-76000 Rouen</p>
+        <address><p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
+                  <p>Coordination dédiée aux chantiers normands</p>
                   <p>+33 (0)2 35 89 11 20</p>
-                        <a href="https://www.google.com/maps/search/?api=1&query=12+place+Saint-Marc+76000+Rouen" data-fancybox data-width="640" data-height="360">NOUS RENDRE VISITE</a>
+                        <a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">NOUS RENDRE VISITE</a>
                         </address>
       </div>
       <!-- end col-4 -->

--- a/certificates.html
+++ b/certificates.html
@@ -63,8 +63,8 @@
 		<figure class="gallery"><img src="images/slide02.jpg" alt="Image"><img src="images/slide03.jpg" alt="Image"></figure>
 		<h6 class="widget-title">ADDRESS</h6>
 		<address class="address">
-			<p>228 Cardigan Road, Leeds<br>
-Geneva Switzerland</p>
+			<p>59, rue de Ponthieu, Bureau 326<br>
+75008 Paris</p>
 		  <p>+1 (850) 344 0 66 #20</p>
 			</address>
 		<h6 class="widget-title">FOLLOW US</h6>
@@ -254,19 +254,19 @@ Geneva Switzerland</p>
     <div class="row">
       <div class="col-lg-4 col-md-6">
         <h6 class="widget-title">HEADQUARTER</h6>
-        <address><p>228 Cardigan Road, Leeds<br>
-Geneva Switzerland</p>
+        <address><p>59, rue de Ponthieu, Bureau 326<br>
+75008 Paris</p>
 		  <p>+1 (850) 344 0 66 #20</p>
-			<a href="https://www.google.com/maps/search/?api=1&query=centurylink+field" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
+			<a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
 			</address>
       </div>
       <!-- end col-4 --> 
 		<div class="col-lg-4 col-md-6">
         <h6 class="widget-title">SALES OFFICES</h6>
-        <address><p>121 South 8th Street, Suite 1200<br>
-Minneapolis MN 55402</p>
+        <address><p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
+                  <p>Paris, Île-de-France</p>
 		  <p>+1 (850) 344 0 66 #20</p>
-			<a href="https://www.google.com/maps/search/?api=1&query=centurylink+field" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
+			<a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
 			</address>
       </div>
       <!-- end col-4 --> 

--- a/contact.html
+++ b/contact.html
@@ -82,9 +82,11 @@
     "foundingDate": "2025",
     "address": {
       "@type": "PostalAddress",
-      "addressCountry": "FR",
-      "addressRegion": "Normandie",
-      "addressLocality": "Eure"
+      "streetAddress": "59, rue de Ponthieu, Bureau 326",
+      "postalCode": "75008",
+      "addressLocality": "Paris",
+      "addressRegion": "Île-de-France",
+      "addressCountry": "FR"
     },
     "sameAs": [
       "https://www.linkedin.com/company/renogo",
@@ -155,7 +157,8 @@
 
       <h6 class="widget-title">ADRESSE</h6>
       <address class="address">
-        <p>Paris (Île-de-France) — Coordination des projets<br>
+        <p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
+        <p>Coordination des projets en Île-de-France<br>
            Interventions en Normandie (Rouen, Caen, Évreux…)</p>
         <p>+33 2 32 00 00 05</p>
       </address>
@@ -246,7 +249,7 @@
         <div class="contact-box">
                         <figure><img src="images/icon-global.png" alt="Bureaux RenoGo"></figure>
           <h6>Maison RenoGo</h6>
-                <p>24 rue de Turenne, Paris 3e<br></p>
+                <p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
 
         </div>
         <!-- end contact-box -->
@@ -325,7 +328,7 @@
 </section>
 <!-- end content-section -->
                 <section class="content-section no-spacing">
-  <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2665.1609898587347!2d-0.3606132232184785!3d49.18352927853969!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x480a6b0af1d0f3f1%3A0x40c14484fb81290!2sCaen%2C%20France!5e0!3m2!1sfr!2sfr!4v1700000000000" frameborder="0" class="google-maps" allowfullscreen="" aria-hidden="false" tabindex="0"></iframe>
+  <iframe src="https://www.google.com/maps?q=59%20Rue%20de%20Ponthieu%2C%20Bureau%20326%2C%2075008%20Paris&output=embed" frameborder="0" class="google-maps" allowfullscreen="" aria-hidden="false" tabindex="0"></iframe>
 </section>
 <!-- end content-section -->
  <section class="footer-bar">
@@ -359,19 +362,19 @@
     <div class="row">
       <div class="col-lg-4 col-md-6">
         <h6 class="widget-title">Bureau principal</h6>
-        <address><p>24 rue de Turenne, Paris 3e<br>
-Permanence Normandie : 11 quai de la Bourse, Rouen</p>
+        <address><p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
+                  <p>Permanence Normandie : 11 quai de la Bourse, Rouen</p>
                   <p>+33 (0)1 84 60 22 90</p>
-                        <a href="https://www.google.com/maps/search/?api=1&query=11+quai+de+la+Bourse+Rouen" data-fancybox data-width="640" data-height="360">Nous trouver</a>
+                        <a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">Nous trouver</a>
                         </address>
       </div>
       <!-- end col-4 -->
                 <div class="col-lg-4 col-md-6">
         <h6 class="widget-title">Agences locales</h6>
         <address><p>Atelier mobile : Caen, Le Havre, Deauville<br>
-Interventions 6J/7 sur rendez-vous</p>
+Coordination depuis Paris — rendez-vous 6J/7</p>
                   <p>+33 (0)7 68 90 45 12</p>
-                        <a href="https://www.google.com/maps/search/?api=1&query=Normandie" data-fancybox data-width="640" data-height="360">Zones couvertes</a>
+                        <a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">Planifier un rendez-vous</a>
                         </address>
       </div>
       <!-- end col-4 -->

--- a/core-values.html
+++ b/core-values.html
@@ -63,8 +63,8 @@
 		<figure class="gallery"><img src="images/slide02.jpg" alt="Image"><img src="images/slide03.jpg" alt="Image"></figure>
 		<h6 class="widget-title">ADDRESS</h6>
 		<address class="address">
-			<p>228 Cardigan Road, Leeds<br>
-Geneva Switzerland</p>
+			<p>59, rue de Ponthieu, Bureau 326<br>
+75008 Paris</p>
 		  <p>+1 (850) 344 0 66 #20</p>
 			</address>
 		<h6 class="widget-title">FOLLOW US</h6>
@@ -424,19 +424,19 @@ Geneva Switzerland</p>
     <div class="row">
       <div class="col-lg-4 col-md-6">
         <h6 class="widget-title">HEADQUARTER</h6>
-        <address><p>228 Cardigan Road, Leeds<br>
-Geneva Switzerland</p>
+        <address><p>59, rue de Ponthieu, Bureau 326<br>
+75008 Paris</p>
 		  <p>+1 (850) 344 0 66 #20</p>
-			<a href="https://www.google.com/maps/search/?api=1&query=centurylink+field" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
+			<a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
 			</address>
       </div>
       <!-- end col-4 --> 
 		<div class="col-lg-4 col-md-6">
         <h6 class="widget-title">SALES OFFICES</h6>
-        <address><p>121 South 8th Street, Suite 1200<br>
-Minneapolis MN 55402</p>
+        <address><p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
+                  <p>Paris, Île-de-France</p>
 		  <p>+1 (850) 344 0 66 #20</p>
-			<a href="https://www.google.com/maps/search/?api=1&query=centurylink+field" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
+			<a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
 			</address>
       </div>
       <!-- end col-4 --> 

--- a/index.html
+++ b/index.html
@@ -82,9 +82,11 @@
     "foundingDate": "2025",
     "address": {
       "@type": "PostalAddress",
-      "addressCountry": "FR",
-      "addressRegion": "Normandie",
-      "addressLocality": "Eure"
+      "streetAddress": "59, rue de Ponthieu, Bureau 326",
+      "postalCode": "75008",
+      "addressLocality": "Paris",
+      "addressRegion": "Île-de-France",
+      "addressCountry": "FR"
     },
     "sameAs": [
       "https://www.linkedin.com/company/renogo",
@@ -155,7 +157,8 @@
 
       <h6 class="widget-title">ADRESSE</h6>
       <address class="address">
-        <p>Paris (Île-de-France) — Coordination des projets<br>
+        <p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
+        <p>Coordination des projets en Île-de-France<br>
            Interventions en Normandie (Rouen, Caen, Évreux…)</p>
         <p>+33 2 32 00 00 05</p>
       </address>

--- a/leadership.html
+++ b/leadership.html
@@ -63,8 +63,8 @@
 		<figure class="gallery"><img src="images/slide02.jpg" alt="Image"><img src="images/slide03.jpg" alt="Image"></figure>
 		<h6 class="widget-title">ADDRESS</h6>
 		<address class="address">
-			<p>228 Cardigan Road, Leeds<br>
-Geneva Switzerland</p>
+			<p>59, rue de Ponthieu, Bureau 326<br>
+75008 Paris</p>
 		  <p>+1 (850) 344 0 66 #20</p>
 			</address>
 		<h6 class="widget-title">FOLLOW US</h6>
@@ -428,19 +428,19 @@ Geneva Switzerland</p>
     <div class="row">
       <div class="col-lg-4 col-md-6">
         <h6 class="widget-title">HEADQUARTER</h6>
-        <address><p>228 Cardigan Road, Leeds<br>
-Geneva Switzerland</p>
+        <address><p>59, rue de Ponthieu, Bureau 326<br>
+75008 Paris</p>
 		  <p>+1 (850) 344 0 66 #20</p>
-			<a href="https://www.google.com/maps/search/?api=1&query=centurylink+field" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
+			<a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
 			</address>
       </div>
       <!-- end col-4 --> 
 		<div class="col-lg-4 col-md-6">
         <h6 class="widget-title">SALES OFFICES</h6>
-        <address><p>121 South 8th Street, Suite 1200<br>
-Minneapolis MN 55402</p>
+        <address><p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
+                  <p>Paris, Île-de-France</p>
 		  <p>+1 (850) 344 0 66 #20</p>
-			<a href="https://www.google.com/maps/search/?api=1&query=centurylink+field" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
+			<a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
 			</address>
       </div>
       <!-- end col-4 --> 

--- a/news-sing.html
+++ b/news-sing.html
@@ -63,8 +63,8 @@
 		<figure class="gallery"><img src="images/slide02.jpg" alt="Image"><img src="images/slide03.jpg" alt="Image"></figure>
 		<h6 class="widget-title">ADDRESS</h6>
 		<address class="address">
-			<p>228 Cardigan Road, Leeds<br>
-Geneva Switzerland</p>
+			<p>59, rue de Ponthieu, Bureau 326<br>
+75008 Paris</p>
 		  <p>+1 (850) 344 0 66 #20</p>
 			</address>
 		<h6 class="widget-title">FOLLOW US</h6>
@@ -278,19 +278,19 @@ Geneva Switzerland</p>
     <div class="row">
       <div class="col-lg-4 col-md-6">
         <h6 class="widget-title">HEADQUARTER</h6>
-        <address><p>228 Cardigan Road, Leeds<br>
-Geneva Switzerland</p>
+        <address><p>59, rue de Ponthieu, Bureau 326<br>
+75008 Paris</p>
 		  <p>+1 (850) 344 0 66 #20</p>
-			<a href="https://www.google.com/maps/search/?api=1&query=centurylink+field" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
+			<a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
 			</address>
       </div>
       <!-- end col-4 --> 
 		<div class="col-lg-4 col-md-6">
         <h6 class="widget-title">SALES OFFICES</h6>
-        <address><p>121 South 8th Street, Suite 1200<br>
-Minneapolis MN 55402</p>
+        <address><p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
+                  <p>Paris, Île-de-France</p>
 		  <p>+1 (850) 344 0 66 #20</p>
-			<a href="https://www.google.com/maps/search/?api=1&query=centurylink+field" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
+			<a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
 			</address>
       </div>
       <!-- end col-4 --> 

--- a/news.html
+++ b/news.html
@@ -82,9 +82,11 @@
     "foundingDate": "2025",
     "address": {
       "@type": "PostalAddress",
-      "addressCountry": "FR",
-      "addressRegion": "Normandie",
-      "addressLocality": "Eure"
+      "streetAddress": "59, rue de Ponthieu, Bureau 326",
+      "postalCode": "75008",
+      "addressLocality": "Paris",
+      "addressRegion": "Île-de-France",
+      "addressCountry": "FR"
     },
     "sameAs": [
       "https://www.linkedin.com/company/renogo",
@@ -155,7 +157,8 @@
 
       <h6 class="widget-title">ADRESSE</h6>
       <address class="address">
-        <p>Paris (Île-de-France) — Coordination des projets<br>
+        <p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
+        <p>Coordination des projets en Île-de-France<br>
            Interventions en Normandie (Rouen, Caen, Évreux…)</p>
         <p>+33 2 32 00 00 05</p>
       </address>
@@ -476,19 +479,19 @@
     <div class="row">
       <div class="col-lg-4 col-md-6">
         <h6 class="widget-title">SIÈGE SOCIAL</h6>
-        <address><p>48 rue de Rivoli, 75004 Paris<br>
-France</p>
+        <address><p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
+                  <p>France</p>
                   <p>+33 1 84 80 12 45</p>
-                        <a href="https://www.google.com/maps/search/?api=1&query=48+rue+de+Rivoli+Paris" data-fancybox data-width="640" data-height="360">Nous trouver</a>
+                        <a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">Nous trouver</a>
                         </address>
       </div>
       <!-- end col-4 -->
                 <div class="col-lg-4 col-md-6">
         <h6 class="widget-title">ANTENNES NORMANDES</h6>
-        <address><p>12 rue du Port, 76600 Le Havre<br>
-Normandie</p>
+        <address><p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
+                  <p>Coordination des antennes normandes</p>
                   <p>+33 2 32 12 45 78</p>
-                        <a href="https://www.google.com/maps/search/?api=1&query=12+rue+du+Port+Le+Havre" data-fancybox data-width="640" data-height="360">Nous rencontrer</a>
+                        <a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">Nous rencontrer</a>
                         </address>
       </div>
       <!-- end col-4 -->

--- a/offices.html
+++ b/offices.html
@@ -63,8 +63,8 @@
 		<figure class="gallery"><img src="images/slide02.jpg" alt="Image"><img src="images/slide03.jpg" alt="Image"></figure>
 		<h6 class="widget-title">ADDRESS</h6>
 		<address class="address">
-			<p>228 Cardigan Road, Leeds<br>
-Geneva Switzerland</p>
+			<p>59, rue de Ponthieu, Bureau 326<br>
+75008 Paris</p>
 		  <p>+1 (850) 344 0 66 #20</p>
 			</address>
 		<h6 class="widget-title">FOLLOW US</h6>
@@ -173,7 +173,7 @@ Geneva Switzerland</p>
         <div class="contact-box"> 
 			<figure><img src="images/icon-paris.png" alt="Image"></figure>
           <h6>Paris Office</h6>
-          	<p>228 Cardigan Road, Leeds<br>
+          	<p>59, rue de Ponthieu, Bureau 326<br>
 Paris France</p>
 		 
         </div>
@@ -184,7 +184,7 @@ Paris France</p>
         <div class="contact-box"> 
 			<figure><img src="images/icon-newyork.png" alt="Image"></figure>
           <h6>New York Office</h6>
-           	<p>228 Cardigan Road, Leeds<br>
+           	<p>59, rue de Ponthieu, Bureau 326<br>
 New York USA</p>
         </div>
         <!-- end contact-box --> 
@@ -194,7 +194,7 @@ New York USA</p>
         <div class="contact-box"> 	
 			<figure><img src="images/icon-roma.png" alt="Image"></figure>
           <h6>Rome Office</h6>
-          	<p>228 Cardigan Road, Leeds<br>
+          	<p>59, rue de Ponthieu, Bureau 326<br>
 Rome Italy</p>
         </div>
         <!-- end contact-box --> 
@@ -237,19 +237,19 @@ Rome Italy</p>
     <div class="row">
       <div class="col-lg-4 col-md-6">
         <h6 class="widget-title">HEADQUARTER</h6>
-        <address><p>228 Cardigan Road, Leeds<br>
-Geneva Switzerland</p>
+        <address><p>59, rue de Ponthieu, Bureau 326<br>
+75008 Paris</p>
 		  <p>+1 (850) 344 0 66 #20</p>
-			<a href="https://www.google.com/maps/search/?api=1&query=centurylink+field" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
+			<a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
 			</address>
       </div>
       <!-- end col-4 --> 
 		<div class="col-lg-4 col-md-6">
         <h6 class="widget-title">SALES OFFICES</h6>
-        <address><p>121 South 8th Street, Suite 1200<br>
-Minneapolis MN 55402</p>
+        <address><p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
+                  <p>Paris, Île-de-France</p>
 		  <p>+1 (850) 344 0 66 #20</p>
-			<a href="https://www.google.com/maps/search/?api=1&query=centurylink+field" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
+			<a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
 			</address>
       </div>
       <!-- end col-4 --> 

--- a/our-history.html
+++ b/our-history.html
@@ -63,8 +63,8 @@
 		<figure class="gallery"><img src="images/slide02.jpg" alt="Image"><img src="images/slide03.jpg" alt="Image"></figure>
 		<h6 class="widget-title">ADDRESS</h6>
 		<address class="address">
-			<p>228 Cardigan Road, Leeds<br>
-Geneva Switzerland</p>
+			<p>59, rue de Ponthieu, Bureau 326<br>
+75008 Paris</p>
 		  <p>+1 (850) 344 0 66 #20</p>
 			</address>
 		<h6 class="widget-title">FOLLOW US</h6>
@@ -273,19 +273,19 @@ Geneva Switzerland</p>
     <div class="row">
       <div class="col-lg-4 col-md-6">
         <h6 class="widget-title">HEADQUARTER</h6>
-        <address><p>228 Cardigan Road, Leeds<br>
-Geneva Switzerland</p>
+        <address><p>59, rue de Ponthieu, Bureau 326<br>
+75008 Paris</p>
 		  <p>+1 (850) 344 0 66 #20</p>
-			<a href="https://www.google.com/maps/search/?api=1&query=centurylink+field" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
+			<a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
 			</address>
       </div>
       <!-- end col-4 --> 
 		<div class="col-lg-4 col-md-6">
         <h6 class="widget-title">SALES OFFICES</h6>
-        <address><p>121 South 8th Street, Suite 1200<br>
-Minneapolis MN 55402</p>
+        <address><p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
+                  <p>Paris, Île-de-France</p>
 		  <p>+1 (850) 344 0 66 #20</p>
-			<a href="https://www.google.com/maps/search/?api=1&query=centurylink+field" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
+			<a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
 			</address>
       </div>
       <!-- end col-4 --> 

--- a/project-single.html
+++ b/project-single.html
@@ -63,8 +63,8 @@
 		<figure class="gallery"><img src="images/slide02.jpg" alt="Image"><img src="images/slide03.jpg" alt="Image"></figure>
 		<h6 class="widget-title">ADDRESS</h6>
 		<address class="address">
-			<p>228 Cardigan Road, Leeds<br>
-Geneva Switzerland</p>
+			<p>59, rue de Ponthieu, Bureau 326<br>
+75008 Paris</p>
 		  <p>+1 (850) 344 0 66 #20</p>
 			</address>
 		<h6 class="widget-title">FOLLOW US</h6>
@@ -362,19 +362,19 @@ Geneva Switzerland</p>
     <div class="row">
       <div class="col-lg-4 col-md-6">
         <h6 class="widget-title">HEADQUARTER</h6>
-        <address><p>228 Cardigan Road, Leeds<br>
-Geneva Switzerland</p>
+        <address><p>59, rue de Ponthieu, Bureau 326<br>
+75008 Paris</p>
 		  <p>+1 (850) 344 0 66 #20</p>
-			<a href="https://www.google.com/maps/search/?api=1&query=centurylink+field" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
+			<a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
 			</address>
       </div>
       <!-- end col-4 --> 
 		<div class="col-lg-4 col-md-6">
         <h6 class="widget-title">SALES OFFICES</h6>
-        <address><p>121 South 8th Street, Suite 1200<br>
-Minneapolis MN 55402</p>
+        <address><p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
+                  <p>Paris, Île-de-France</p>
 		  <p>+1 (850) 344 0 66 #20</p>
-			<a href="https://www.google.com/maps/search/?api=1&query=centurylink+field" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
+			<a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
 			</address>
       </div>
       <!-- end col-4 --> 

--- a/projects.html
+++ b/projects.html
@@ -82,9 +82,11 @@
     "foundingDate": "2025",
     "address": {
       "@type": "PostalAddress",
-      "addressCountry": "FR",
-      "addressRegion": "Normandie",
-      "addressLocality": "Eure"
+      "streetAddress": "59, rue de Ponthieu, Bureau 326",
+      "postalCode": "75008",
+      "addressLocality": "Paris",
+      "addressRegion": "Île-de-France",
+      "addressCountry": "FR"
     },
     "sameAs": [
       "https://www.linkedin.com/company/renogo",
@@ -155,7 +157,8 @@
 
       <h6 class="widget-title">ADRESSE</h6>
       <address class="address">
-        <p>Paris (Île-de-France) — Coordination des projets<br>
+        <p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
+        <p>Coordination des projets en Île-de-France<br>
            Interventions en Normandie (Rouen, Caen, Évreux…)</p>
         <p>+33 2 32 00 00 05</p>
       </address>
@@ -492,18 +495,18 @@
         <div class="col-lg-4 col-md-6">
           <h6 class="widget-title">SIÈGE SOCIAL</h6>
           <address>
-            <p>42 rue du Faubourg Saint-Antoine<br>75012 Paris</p>
+            <p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
             <p>+33 (0)1 86 90 12 45</p>
-            <a href="https://www.google.com/maps/search/?api=1&query=42+rue+du+Faubourg+Saint-Antoine+75012+Paris" data-fancybox data-width="640" data-height="360">NOUS LOCALISER</a>
+            <a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">NOUS LOCALISER</a>
           </address>
         </div>
         <!-- end col-4 -->
         <div class="col-lg-4 col-md-6">
           <h6 class="widget-title">BASE NORMANDE</h6>
           <address>
-            <p>Atelier logistique – Zone d'activité du Pays d'Auge<br>14130 Pont-l'Évêque</p>
+            <p>Coordination depuis Paris pour vos projets normands<br>59, rue de Ponthieu, Bureau 326 – 75008 Paris</p>
             <p>+33 (0)2 79 02 45 11</p>
-            <a href="https://www.google.com/maps/search/?api=1&query=Pont-l%27Ev%C3%AAque+Normandie" data-fancybox data-width="640" data-height="360">PLAN D'ACCÈS</a>
+            <a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">PLAN D'ACCÈS</a>
           </address>
         </div>
         <!-- end col-4 -->

--- a/services.html
+++ b/services.html
@@ -82,9 +82,11 @@
     "foundingDate": "2025",
     "address": {
       "@type": "PostalAddress",
-      "addressCountry": "FR",
-      "addressRegion": "Normandie",
-      "addressLocality": "Eure"
+      "streetAddress": "59, rue de Ponthieu, Bureau 326",
+      "postalCode": "75008",
+      "addressLocality": "Paris",
+      "addressRegion": "Île-de-France",
+      "addressCountry": "FR"
     },
     "sameAs": [
       "https://www.linkedin.com/company/renogo",
@@ -155,7 +157,8 @@
 
       <h6 class="widget-title">ADRESSE</h6>
       <address class="address">
-        <p>Paris (Île-de-France) — Coordination des projets<br>
+        <p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
+        <p>Coordination des projets en Île-de-France<br>
            Interventions en Normandie (Rouen, Caen, Évreux…)</p>
         <p>+33 2 32 00 00 05</p>
       </address>
@@ -526,20 +529,18 @@
       <div class="col-lg-4 col-md-6">
         <h6 class="widget-title">SIÈGE SOCIAL</h6>
         <address>
-        <p>42 rue du Faubourg Saint-Antoine<br>
-          75012 Paris</p>
+        <p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
         <p>+33 (0)1 86 90 12 45</p>
-        <a href="https://www.google.com/maps/search/?api=1&query=42+rue+du+Faubourg+Saint-Antoine+75012+Paris" data-fancybox data-width="640" data-height="360">NOUS LOCALISER</a>
+        <a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">NOUS LOCALISER</a>
         </address>
       </div>
       <!-- end col-4 -->
       <div class="col-lg-4 col-md-6">
         <h6 class="widget-title">BASE NORMANDE</h6>
         <address>
-        <p>Atelier logistique – Zone d'activité du Pays d'Auge<br>
-          14130 Pont-l'Évêque</p>
+        <p>Coordination depuis Paris pour vos projets normands<br>          59, rue de Ponthieu, Bureau 326 – 75008 Paris</p>
         <p>+33 (0)2 79 02 45 11</p>
-        <a href="https://www.google.com/maps/search/?api=1&query=Pont-l%27Ev%C3%AAque+Normandie" data-fancybox data-width="640" data-height="360">PLAN D'ACCÈS</a>
+        <a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">PLAN D'ACCÈS</a>
         </address>
       </div>
       <!-- end col-4 -->


### PR DESCRIPTION
## Summary
- replace all hard-coded office addresses with 59, rue de Ponthieu, Bureau 326, 75008 Paris across public pages
- update structured data, contact cards, footer details, and map links to reflect the new headquarters location
- refresh supporting copy so Normandie coverage references originate from the Paris office

## Testing
- not run (static content changes)

------
https://chatgpt.com/codex/tasks/task_e_68d7afacc53c832e981ab352404ea542