### PR TITLE
Remove local agency footer columns from all pages

### DIFF
--- a/about-company.html
+++ b/about-company.html
@@ -631,24 +631,15 @@
 <footer class="footer">
   <div class="container">
     <div class="row">
-      <div class="col-lg-4 col-md-6">
+      <div class="col-lg-6 col-md-6">
         <h6 class="widget-title">SIÈGE SOCIAL</h6>
         <address><p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
                   <p>+33 (0)1 86 76 90 12</p>
                         <a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">NOUS LOCALISER</a>
                         </address>
       </div>
-      <!-- end col-4 -->
-                <div class="col-lg-4 col-md-6">
-        <h6 class="widget-title">AGENCE NORMANDIE</h6>
-        <address><p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
-                  <p>Coordination dédiée aux chantiers normands</p>
-                  <p>+33 (0)2 35 89 11 20</p>
-                        <a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">NOUS RENDRE VISITE</a>
-                        </address>
-      </div>
-      <!-- end col-4 -->
-                <div class="col-lg-4">
+      <!-- end col-6 -->
+                <div class="col-lg-6">
         <h6 class="widget-title">REJOIGNEZ NOTRE LETTRE</h6>
        <p>Recevez chaque mois nos conseils travaux, calendrier d'entretien et offres locales.</p>
                         <form>
@@ -656,7 +647,7 @@
                                 <input type="submit" value="JE M'INSCRIS">
                         </form>
       </div>
-      <!-- end col-4 -->
+      <!-- end col-6 -->
                 <div class="col-12">
                         <div class="footer-bottom">
                                 <span>© 2024 RenoGo. Tous droits réservés.</span>

--- a/certificates.html
+++ b/certificates.html
@@ -252,33 +252,24 @@
 <footer class="footer">
   <div class="container">
     <div class="row">
-      <div class="col-lg-4 col-md-6">
+      <div class="col-lg-6 col-md-6">
         <h6 class="widget-title">HEADQUARTER</h6>
         <address><p>59, rue de Ponthieu, Bureau 326<br>
 75008 Paris</p>
-		  <p>+1 (850) 344 0 66 #20</p>
-			<a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
-			</address>
+                  <p>+1 (850) 344 0 66 #20</p>
+                        <a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
+                        </address>
       </div>
-      <!-- end col-4 --> 
-		<div class="col-lg-4 col-md-6">
-        <h6 class="widget-title">SALES OFFICES</h6>
-        <address><p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
-                  <p>Paris, Île-de-France</p>
-		  <p>+1 (850) 344 0 66 #20</p>
-			<a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
-			</address>
-      </div>
-      <!-- end col-4 --> 
-		<div class="col-lg-4">
+      <!-- end col-6 -->
+                <div class="col-lg-6">
         <h6 class="widget-title">SUBSCRIPTION</h6>
        <p>For more information, please join us.</p>
-			<form>
-			<input type="email" placeholder="Type your e-mail">
-				<input type="submit" value="JOIN NOW">
-			</form>
+                        <form>
+                        <input type="email" placeholder="Type your e-mail">
+                                <input type="submit" value="JOIN NOW">
+                        </form>
       </div>
-      <!-- end col-4 --> 
+      <!-- end col-6 -->
 		<div class="col-12">
 			<div class="footer-bottom">
 				<span>© 2020 Consto | Industrial Construction Company</span>

--- a/contact.html
+++ b/contact.html
@@ -360,7 +360,7 @@
 <footer class="footer">
   <div class="container">
     <div class="row">
-      <div class="col-lg-4 col-md-6">
+      <div class="col-lg-6 col-md-6">
         <h6 class="widget-title">Bureau principal</h6>
         <address><p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
                   <p>Permanence Normandie : 11 quai de la Bourse, Rouen</p>
@@ -368,17 +368,8 @@
                         <a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">Nous trouver</a>
                         </address>
       </div>
-      <!-- end col-4 -->
-                <div class="col-lg-4 col-md-6">
-        <h6 class="widget-title">Agences locales</h6>
-        <address><p>Atelier mobile : Caen, Le Havre, Deauville<br>
-Coordination depuis Paris — rendez-vous 6J/7</p>
-                  <p>+33 (0)7 68 90 45 12</p>
-                        <a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">Planifier un rendez-vous</a>
-                        </address>
-      </div>
-      <!-- end col-4 -->
-                <div class="col-lg-4">
+      <!-- end col-6 -->
+                <div class="col-lg-6">
         <h6 class="widget-title">Lettre d'inspiration</h6>
        <p>Recevez nos conseils saisonniers pour protéger et sublimer vos espaces intérieurs et extérieurs.</p>
                         <form>
@@ -386,7 +377,7 @@ Coordination depuis Paris — rendez-vous 6J/7</p>
                                 <input type="submit" value="JE M'INSCRIS">
                         </form>
       </div>
-      <!-- end col-4 -->
+      <!-- end col-6 -->
                 <div class="col-12">
                         <div class="footer-bottom">
                                 <span>© 2024 RenoGo | Rénovation, Maintenance & Paysage en Normandie</span>

--- a/core-values.html
+++ b/core-values.html
@@ -422,33 +422,24 @@
 <footer class="footer">
   <div class="container">
     <div class="row">
-      <div class="col-lg-4 col-md-6">
+      <div class="col-lg-6 col-md-6">
         <h6 class="widget-title">HEADQUARTER</h6>
         <address><p>59, rue de Ponthieu, Bureau 326<br>
 75008 Paris</p>
-		  <p>+1 (850) 344 0 66 #20</p>
-			<a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
-			</address>
+                  <p>+1 (850) 344 0 66 #20</p>
+                        <a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
+                        </address>
       </div>
-      <!-- end col-4 --> 
-		<div class="col-lg-4 col-md-6">
-        <h6 class="widget-title">SALES OFFICES</h6>
-        <address><p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
-                  <p>Paris, Île-de-France</p>
-		  <p>+1 (850) 344 0 66 #20</p>
-			<a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
-			</address>
-      </div>
-      <!-- end col-4 --> 
-		<div class="col-lg-4">
+      <!-- end col-6 -->
+                <div class="col-lg-6">
         <h6 class="widget-title">SUBSCRIPTION</h6>
        <p>For more information, please join us.</p>
-			<form>
-			<input type="email" placeholder="Type your e-mail">
-				<input type="submit" value="JOIN NOW">
-			</form>
+                        <form>
+                        <input type="email" placeholder="Type your e-mail">
+                                <input type="submit" value="JOIN NOW">
+                        </form>
       </div>
-      <!-- end col-4 --> 
+      <!-- end col-6 -->
 		<div class="col-12">
 			<div class="footer-bottom">
 				<span>© 2020 Consto | Industrial Construction Company</span>

--- a/leadership.html
+++ b/leadership.html
@@ -426,33 +426,24 @@
 <footer class="footer">
   <div class="container">
     <div class="row">
-      <div class="col-lg-4 col-md-6">
+      <div class="col-lg-6 col-md-6">
         <h6 class="widget-title">HEADQUARTER</h6>
         <address><p>59, rue de Ponthieu, Bureau 326<br>
 75008 Paris</p>
-		  <p>+1 (850) 344 0 66 #20</p>
-			<a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
-			</address>
+                  <p>+1 (850) 344 0 66 #20</p>
+                        <a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
+                        </address>
       </div>
-      <!-- end col-4 --> 
-		<div class="col-lg-4 col-md-6">
-        <h6 class="widget-title">SALES OFFICES</h6>
-        <address><p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
-                  <p>Paris, Île-de-France</p>
-		  <p>+1 (850) 344 0 66 #20</p>
-			<a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
-			</address>
-      </div>
-      <!-- end col-4 --> 
-		<div class="col-lg-4">
+      <!-- end col-6 -->
+                <div class="col-lg-6">
         <h6 class="widget-title">SUBSCRIPTION</h6>
        <p>For more information, please join us.</p>
-			<form>
-			<input type="email" placeholder="Type your e-mail">
-				<input type="submit" value="JOIN NOW">
-			</form>
+                        <form>
+                        <input type="email" placeholder="Type your e-mail">
+                                <input type="submit" value="JOIN NOW">
+                        </form>
       </div>
-      <!-- end col-4 --> 
+      <!-- end col-6 -->
 		<div class="col-12">
 			<div class="footer-bottom">
 				<span>© 2020 Consto | Industrial Construction Company</span>

--- a/news-sing.html
+++ b/news-sing.html
@@ -276,33 +276,24 @@
 <footer class="footer">
   <div class="container">
     <div class="row">
-      <div class="col-lg-4 col-md-6">
+      <div class="col-lg-6 col-md-6">
         <h6 class="widget-title">HEADQUARTER</h6>
         <address><p>59, rue de Ponthieu, Bureau 326<br>
 75008 Paris</p>
-		  <p>+1 (850) 344 0 66 #20</p>
-			<a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
-			</address>
+                  <p>+1 (850) 344 0 66 #20</p>
+                        <a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
+                        </address>
       </div>
-      <!-- end col-4 --> 
-		<div class="col-lg-4 col-md-6">
-        <h6 class="widget-title">SALES OFFICES</h6>
-        <address><p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
-                  <p>Paris, Île-de-France</p>
-		  <p>+1 (850) 344 0 66 #20</p>
-			<a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
-			</address>
-      </div>
-      <!-- end col-4 --> 
-		<div class="col-lg-4">
+      <!-- end col-6 -->
+                <div class="col-lg-6">
         <h6 class="widget-title">SUBSCRIPTION</h6>
        <p>For more information, please join us.</p>
-			<form>
-			<input type="email" placeholder="Type your e-mail">
-				<input type="submit" value="JOIN NOW">
-			</form>
+                        <form>
+                        <input type="email" placeholder="Type your e-mail">
+                                <input type="submit" value="JOIN NOW">
+                        </form>
       </div>
-      <!-- end col-4 --> 
+      <!-- end col-6 -->
 		<div class="col-12">
 			<div class="footer-bottom">
 				<span>© 2020 Consto | Industrial Construction Company</span>

--- a/news.html
+++ b/news.html
@@ -477,7 +477,7 @@
 <footer class="footer">
   <div class="container">
     <div class="row">
-      <div class="col-lg-4 col-md-6">
+      <div class="col-lg-6 col-md-6">
         <h6 class="widget-title">SIÈGE SOCIAL</h6>
         <address><p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
                   <p>France</p>
@@ -485,17 +485,8 @@
                         <a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">Nous trouver</a>
                         </address>
       </div>
-      <!-- end col-4 -->
-                <div class="col-lg-4 col-md-6">
-        <h6 class="widget-title">ANTENNES NORMANDES</h6>
-        <address><p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
-                  <p>Coordination des antennes normandes</p>
-                  <p>+33 2 32 12 45 78</p>
-                        <a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">Nous rencontrer</a>
-                        </address>
-      </div>
-      <!-- end col-4 -->
-                <div class="col-lg-4">
+      <!-- end col-6 -->
+                <div class="col-lg-6">
         <h6 class="widget-title">INSCRIPTION</h6>
        <p>Recevez nos conseils saisonniers et offres exclusives.</p>
                         <form>
@@ -503,7 +494,7 @@
                                 <input type="submit" value="JE M'INSCRIS">
                         </form>
       </div>
-      <!-- end col-4 -->
+      <!-- end col-6 -->
                 <div class="col-12">
                         <div class="footer-bottom">
                                 <span>© 2024 RenoGo | Rénovation, maintenance et aménagements en Normandie</span>

--- a/offices.html
+++ b/offices.html
@@ -235,33 +235,24 @@ Rome Italy</p>
 <footer class="footer">
   <div class="container">
     <div class="row">
-      <div class="col-lg-4 col-md-6">
+      <div class="col-lg-6 col-md-6">
         <h6 class="widget-title">HEADQUARTER</h6>
         <address><p>59, rue de Ponthieu, Bureau 326<br>
 75008 Paris</p>
-		  <p>+1 (850) 344 0 66 #20</p>
-			<a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
-			</address>
+                  <p>+1 (850) 344 0 66 #20</p>
+                        <a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
+                        </address>
       </div>
-      <!-- end col-4 --> 
-		<div class="col-lg-4 col-md-6">
-        <h6 class="widget-title">SALES OFFICES</h6>
-        <address><p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
-                  <p>Paris, Île-de-France</p>
-		  <p>+1 (850) 344 0 66 #20</p>
-			<a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
-			</address>
-      </div>
-      <!-- end col-4 --> 
-		<div class="col-lg-4">
+      <!-- end col-6 -->
+                <div class="col-lg-6">
         <h6 class="widget-title">SUBSCRIPTION</h6>
        <p>For more information, please join us.</p>
-			<form>
-			<input type="email" placeholder="Type your e-mail">
-				<input type="submit" value="JOIN NOW">
-			</form>
+                        <form>
+                        <input type="email" placeholder="Type your e-mail">
+                                <input type="submit" value="JOIN NOW">
+                        </form>
       </div>
-      <!-- end col-4 --> 
+      <!-- end col-6 -->
 		<div class="col-12">
 			<div class="footer-bottom">
 				<span>© 2020 Consto | Industrial Construction Company</span>

--- a/our-history.html
+++ b/our-history.html
@@ -271,33 +271,24 @@
 <footer class="footer">
   <div class="container">
     <div class="row">
-      <div class="col-lg-4 col-md-6">
+      <div class="col-lg-6 col-md-6">
         <h6 class="widget-title">HEADQUARTER</h6>
         <address><p>59, rue de Ponthieu, Bureau 326<br>
 75008 Paris</p>
-		  <p>+1 (850) 344 0 66 #20</p>
-			<a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
-			</address>
+                  <p>+1 (850) 344 0 66 #20</p>
+                        <a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
+                        </address>
       </div>
-      <!-- end col-4 --> 
-		<div class="col-lg-4 col-md-6">
-        <h6 class="widget-title">SALES OFFICES</h6>
-        <address><p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
-                  <p>Paris, Île-de-France</p>
-		  <p>+1 (850) 344 0 66 #20</p>
-			<a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
-			</address>
-      </div>
-      <!-- end col-4 --> 
-		<div class="col-lg-4">
+      <!-- end col-6 -->
+                <div class="col-lg-6">
         <h6 class="widget-title">SUBSCRIPTION</h6>
        <p>For more information, please join us.</p>
-			<form>
-			<input type="email" placeholder="Type your e-mail">
-				<input type="submit" value="JOIN NOW">
-			</form>
+                        <form>
+                        <input type="email" placeholder="Type your e-mail">
+                                <input type="submit" value="JOIN NOW">
+                        </form>
       </div>
-      <!-- end col-4 --> 
+      <!-- end col-6 -->
 		<div class="col-12">
 			<div class="footer-bottom">
 				<span>© 2020 Consto | Industrial Construction Company</span>

--- a/project-single.html
+++ b/project-single.html
@@ -360,33 +360,24 @@
 <footer class="footer">
   <div class="container">
     <div class="row">
-      <div class="col-lg-4 col-md-6">
+      <div class="col-lg-6 col-md-6">
         <h6 class="widget-title">HEADQUARTER</h6>
         <address><p>59, rue de Ponthieu, Bureau 326<br>
 75008 Paris</p>
-		  <p>+1 (850) 344 0 66 #20</p>
-			<a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
-			</address>
+                  <p>+1 (850) 344 0 66 #20</p>
+                        <a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
+                        </address>
       </div>
-      <!-- end col-4 --> 
-		<div class="col-lg-4 col-md-6">
-        <h6 class="widget-title">SALES OFFICES</h6>
-        <address><p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
-                  <p>Paris, Île-de-France</p>
-		  <p>+1 (850) 344 0 66 #20</p>
-			<a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
-			</address>
-      </div>
-      <!-- end col-4 --> 
-		<div class="col-lg-4">
+      <!-- end col-6 -->
+                <div class="col-lg-6">
         <h6 class="widget-title">SUBSCRIPTION</h6>
        <p>For more information, please join us.</p>
-			<form>
-			<input type="email" placeholder="Type your e-mail">
-				<input type="submit" value="JOIN NOW">
-			</form>
+                        <form>
+                        <input type="email" placeholder="Type your e-mail">
+                                <input type="submit" value="JOIN NOW">
+                        </form>
       </div>
-      <!-- end col-4 --> 
+      <!-- end col-6 -->
 		<div class="col-12">
 			<div class="footer-bottom">
 				<span>© 2020 Consto | Industrial Construction Company</span>

--- a/projects.html
+++ b/projects.html
@@ -492,7 +492,7 @@
   <footer class="footer">
     <div class="container">
       <div class="row">
-        <div class="col-lg-4 col-md-6">
+        <div class="col-lg-6 col-md-6">
           <h6 class="widget-title">SIÈGE SOCIAL</h6>
           <address>
             <p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
@@ -500,17 +500,8 @@
             <a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">NOUS LOCALISER</a>
           </address>
         </div>
-        <!-- end col-4 -->
-        <div class="col-lg-4 col-md-6">
-          <h6 class="widget-title">BASE NORMANDE</h6>
-          <address>
-            <p>Coordination depuis Paris pour vos projets normands<br>59, rue de Ponthieu, Bureau 326 – 75008 Paris</p>
-            <p>+33 (0)2 79 02 45 11</p>
-            <a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">PLAN D'ACCÈS</a>
-          </address>
-        </div>
-        <!-- end col-4 -->
-        <div class="col-lg-4">
+        <!-- end col-6 -->
+        <div class="col-lg-6">
           <h6 class="widget-title">RESTONS EN CONTACT</h6>
           <p>Recevez nos conseils saisonniers et nos offres exclusives pour vos projets en Normandie.</p>
           <form>
@@ -518,7 +509,7 @@
             <input type="submit" value="S'INSCRIRE">
           </form>
         </div>
-        <!-- end col-4 -->
+        <!-- end col-6 -->
         <div class="col-12">
           <div class="footer-bottom">
             <span>© 2024 RenoGo | Rénovation, entretien et maintenance en Normandie</span>

--- a/services.html
+++ b/services.html
@@ -526,7 +526,7 @@
 <footer class="footer">
   <div class="container">
     <div class="row">
-      <div class="col-lg-4 col-md-6">
+      <div class="col-lg-6 col-md-6">
         <h6 class="widget-title">SIÈGE SOCIAL</h6>
         <address>
         <p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
@@ -534,17 +534,8 @@
         <a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">NOUS LOCALISER</a>
         </address>
       </div>
-      <!-- end col-4 -->
-      <div class="col-lg-4 col-md-6">
-        <h6 class="widget-title">BASE NORMANDE</h6>
-        <address>
-        <p>Coordination depuis Paris pour vos projets normands<br>          59, rue de Ponthieu, Bureau 326 – 75008 Paris</p>
-        <p>+33 (0)2 79 02 45 11</p>
-        <a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">PLAN D'ACCÈS</a>
-        </address>
-      </div>
-      <!-- end col-4 -->
-      <div class="col-lg-4">
+      <!-- end col-6 -->
+      <div class="col-lg-6">
         <h6 class="widget-title">RESTONS EN CONTACT</h6>
         <p>Recevez nos conseils saisonniers et nos offres exclusives pour vos projets en Normandie.</p>
         <form>
@@ -552,7 +543,7 @@
           <input type="submit" value="S'INSCRIRE">
         </form>
       </div>
-      <!-- end col-4 -->
+      <!-- end col-6 -->
       <div class="col-12">
         <div class="footer-bottom"> <span>© 2024 RenoGo | Rénovation, entretien et maintenance en Normandie</span>
           <ul>


### PR DESCRIPTION
## Summary
- remove the local agency or sales office footer column from every HTML page
- rebalance the remaining footer widgets to share the footer row evenly

## Testing
- not run (static HTML changes)


------
https://chatgpt.com/codex/tasks/task_e_68d7b664c27c832ea07c6b4c5783ac26