### PR TITLE
Standardize Normandie permanence details across footers

### DIFF
--- a/about-company.html
+++ b/about-company.html
@@ -634,6 +634,7 @@
       <div class="col-lg-6 col-md-6">
         <h6 class="widget-title">SIÈGE SOCIAL</h6>
         <address><p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
+                  <p>Permanence Normandie: Rue d'Ezu, La Couture-Boussey</p>
                   <p>+33 (0)1 86 76 90 12</p>
                         <a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">NOUS LOCALISER</a>
                         </address>

--- a/certificates.html
+++ b/certificates.html
@@ -256,6 +256,7 @@
         <h6 class="widget-title">HEADQUARTER</h6>
         <address><p>59, rue de Ponthieu, Bureau 326<br>
 75008 Paris</p>
+                  <p>Permanence Normandie: Rue d'Ezu, La Couture-Boussey</p>
                   <p>+1 (850) 344 0 66 #20</p>
                         <a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
                         </address>

--- a/contact.html
+++ b/contact.html
@@ -363,7 +363,7 @@
       <div class="col-lg-6 col-md-6">
         <h6 class="widget-title">Bureau principal</h6>
         <address><p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
-                  <p>Permanence Normandie : 11 quai de la Bourse, Rouen</p>
+                  <p>Permanence Normandie: Rue d'Ezu, La Couture-Boussey</p>
                   <p>+33 (0)1 84 60 22 90</p>
                         <a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">Nous trouver</a>
                         </address>

--- a/core-values.html
+++ b/core-values.html
@@ -426,6 +426,7 @@
         <h6 class="widget-title">HEADQUARTER</h6>
         <address><p>59, rue de Ponthieu, Bureau 326<br>
 75008 Paris</p>
+                  <p>Permanence Normandie: Rue d'Ezu, La Couture-Boussey</p>
                   <p>+1 (850) 344 0 66 #20</p>
                         <a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
                         </address>

--- a/index.html
+++ b/index.html
@@ -926,6 +926,25 @@
   <div class="container">
     <div class="row">
 
+      <div class="col-lg-6 col-md-6">
+        <h6 class="widget-title">Bureau principal</h6>
+        <address>
+          <p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
+          <p>Permanence Normandie: Rue d'Ezu, La Couture-Boussey</p>
+          <p>+33 (0)1 84 60 22 90</p>
+          <a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">Nous trouver</a>
+        </address>
+      </div>
+      <!-- end col-6 -->
+      <div class="col-lg-6">
+        <h6 class="widget-title">Lettre d'inspiration</h6>
+        <p>Recevez nos conseils saisonniers pour protéger et sublimer vos espaces intérieurs et extérieurs.</p>
+        <form>
+          <input type="email" placeholder="Votre e-mail">
+          <input type="submit" value="JE M'INSCRIS">
+        </form>
+      </div>
+      <!-- end col-6 -->
       <div class="col-12">
         <div class="footer-bottom">
           <span>© 2025 RenoGo • Rénovation intérieure & extérieure — Normandie</span>

--- a/leadership.html
+++ b/leadership.html
@@ -430,6 +430,7 @@
         <h6 class="widget-title">HEADQUARTER</h6>
         <address><p>59, rue de Ponthieu, Bureau 326<br>
 75008 Paris</p>
+                  <p>Permanence Normandie: Rue d'Ezu, La Couture-Boussey</p>
                   <p>+1 (850) 344 0 66 #20</p>
                         <a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
                         </address>

--- a/news-sing.html
+++ b/news-sing.html
@@ -280,6 +280,7 @@
         <h6 class="widget-title">HEADQUARTER</h6>
         <address><p>59, rue de Ponthieu, Bureau 326<br>
 75008 Paris</p>
+                  <p>Permanence Normandie: Rue d'Ezu, La Couture-Boussey</p>
                   <p>+1 (850) 344 0 66 #20</p>
                         <a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
                         </address>

--- a/news.html
+++ b/news.html
@@ -480,6 +480,7 @@
       <div class="col-lg-6 col-md-6">
         <h6 class="widget-title">SIÈGE SOCIAL</h6>
         <address><p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
+                  <p>Permanence Normandie: Rue d'Ezu, La Couture-Boussey</p>
                   <p>France</p>
                   <p>+33 1 84 80 12 45</p>
                         <a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">Nous trouver</a>

--- a/offices.html
+++ b/offices.html
@@ -239,6 +239,7 @@ Rome Italy</p>
         <h6 class="widget-title">HEADQUARTER</h6>
         <address><p>59, rue de Ponthieu, Bureau 326<br>
 75008 Paris</p>
+                  <p>Permanence Normandie: Rue d'Ezu, La Couture-Boussey</p>
                   <p>+1 (850) 344 0 66 #20</p>
                         <a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
                         </address>

--- a/our-history.html
+++ b/our-history.html
@@ -275,6 +275,7 @@
         <h6 class="widget-title">HEADQUARTER</h6>
         <address><p>59, rue de Ponthieu, Bureau 326<br>
 75008 Paris</p>
+                  <p>Permanence Normandie: Rue d'Ezu, La Couture-Boussey</p>
                   <p>+1 (850) 344 0 66 #20</p>
                         <a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
                         </address>

--- a/project-single.html
+++ b/project-single.html
@@ -364,6 +364,7 @@
         <h6 class="widget-title">HEADQUARTER</h6>
         <address><p>59, rue de Ponthieu, Bureau 326<br>
 75008 Paris</p>
+                  <p>Permanence Normandie: Rue d'Ezu, La Couture-Boussey</p>
                   <p>+1 (850) 344 0 66 #20</p>
                         <a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">FIND US ON MAP</a>
                         </address>

--- a/projects.html
+++ b/projects.html
@@ -496,6 +496,7 @@
           <h6 class="widget-title">SIÈGE SOCIAL</h6>
           <address>
             <p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
+            <p>Permanence Normandie: Rue d'Ezu, La Couture-Boussey</p>
             <p>+33 (0)1 86 90 12 45</p>
             <a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">NOUS LOCALISER</a>
           </address>

--- a/services.html
+++ b/services.html
@@ -530,6 +530,7 @@
         <h6 class="widget-title">SIÈGE SOCIAL</h6>
         <address>
         <p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
+        <p>Permanence Normandie: Rue d'Ezu, La Couture-Boussey</p>
         <p>+33 (0)1 86 90 12 45</p>
         <a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">NOUS LOCALISER</a>
         </address>


### PR DESCRIPTION
## Summary
- add the Normandie permanence address line to the footer address blocks on every page
- align the home page footer structure with the shared address and newsletter layout

## Testing
- Not run (static HTML content change)

------
https://chatgpt.com/codex/tasks/task_e_68d7b98788d8832e9d83e40067208be6