### PR TITLE
Ajout d’une popup d’appel et repositionnement du bouton retour en haut

### DIFF
--- a/about-company.html
+++ b/about-company.html
@@ -665,7 +665,7 @@
     <!-- end row -->
   </div>
   <!-- end container -->
-        <a href="#" class="scroll-top"><i class="lni lni-arrow-up"></i>
+        <a href="#" class="scroll-top" aria-label="Retour en haut de la page"><i class="lni lni-arrow-up"></i>
         <small>Retour en haut</small>
         </a>
         <!-- end scroll-top -->

--- a/certificates.html
+++ b/certificates.html
@@ -287,9 +287,9 @@
     <!-- end row --> 
   </div>
   <!-- end container --> 
-	<a href="#" class="scroll-top"><i class="lni lni-arrow-up"></i>
-	<small>Scroll Up</small>
-	</a>
+        <a href="#" class="scroll-top" aria-label="Retour en haut de la page"><i class="lni lni-arrow-up"></i>
+        <small>Retour en haut</small>
+        </a>
 	<!-- end scroll-top -->
 </footer>
 <!-- end footer --> 

--- a/contact.html
+++ b/contact.html
@@ -394,8 +394,8 @@
     <!-- end row -->
   </div>
   <!-- end container -->
-        <a href="#" class="scroll-top"><i class="lni lni-arrow-up"></i>
-        <small>Haut de page</small>
+        <a href="#" class="scroll-top" aria-label="Retour en haut de la page"><i class="lni lni-arrow-up"></i>
+        <small>Retour en haut</small>
         </a>
         <!-- end scroll-top -->
 </footer>

--- a/core-values.html
+++ b/core-values.html
@@ -457,9 +457,9 @@
     <!-- end row --> 
   </div>
   <!-- end container --> 
-	<a href="#" class="scroll-top"><i class="lni lni-arrow-up"></i>
-	<small>Scroll Up</small>
-	</a>
+        <a href="#" class="scroll-top" aria-label="Retour en haut de la page"><i class="lni lni-arrow-up"></i>
+        <small>Retour en haut</small>
+        </a>
 	<!-- end scroll-top -->
 </footer>
 <!-- end footer --> 

--- a/css/style.css
+++ b/css/style.css
@@ -3078,19 +3078,30 @@ a:hover {
   color: #fff;
 }
 .footer .scroll-top {
-  width: 100px;
   background: #ff7a04;
-  position: absolute;
-  right: 30px;
-  top: -30px;
-  z-index: 1;
+  position: fixed;
+  left: 30px;
+  bottom: 30px;
+  right: auto;
+  top: auto;
+  z-index: 1000;
   color: #0b0b0b;
-  text-align: center;
-  padding: 15px 0;
+  padding: 14px 24px;
+  border-radius: 40px;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.2);
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+.footer .scroll-top i {
+  font-size: 18px;
 }
 .footer .scroll-top small {
-  width: 100%;
-  display: block;
+  width: auto;
+  display: inline;
 }
 .footer .widget-title {
   width: 100%;
@@ -3172,6 +3183,88 @@ a:hover {
   opacity: 1;
   text-decoration-color: #ff7a04;
 }
+
+
+.cta-popup-backdrop {
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(11, 11, 11, 0.55);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.35s ease;
+  z-index: 998;
+}
+.cta-popup-backdrop.is-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.cta-popup {
+  position: fixed;
+  right: 40px;
+  bottom: 40px;
+  max-width: 360px;
+  width: calc(100% - 80px);
+  background: #fff;
+  color: #0b0b0b;
+  padding: 32px;
+  border-radius: 24px;
+  box-shadow: 0 35px 55px rgba(11, 11, 11, 0.25);
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(30px);
+  transition: all 0.35s ease;
+  z-index: 999;
+  line-height: 1.6;
+}
+.cta-popup.is-visible {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+.cta-popup h3 {
+  font-size: 28px;
+  line-height: 1.3;
+  margin-bottom: 12px;
+}
+.cta-popup p {
+  margin-bottom: 24px;
+}
+.cta-popup .cta-popup__close {
+  position: absolute;
+  right: 18px;
+  top: 14px;
+  background: transparent;
+  border: none;
+  font-size: 28px;
+  line-height: 1;
+  color: #0b0b0b;
+  cursor: pointer;
+  padding: 0;
+}
+.cta-popup .cta-popup__call {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  background: #ff7a04;
+  color: #0b0b0b;
+  padding: 14px 22px;
+  border-radius: 999px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  text-decoration: none;
+}
+.cta-popup .cta-popup__call:hover {
+  text-decoration: none;
+  color: #0b0b0b;
+  background: #ff941f;
+}
+
 
 /* SALES SPECIALIST FORM */
 #sales-specialist-form {
@@ -3572,6 +3665,12 @@ input::-moz-focus-inner, input::-moz-focus-outer {
   .footer address {
     margin-bottom: 50px;
   }
+
+  .cta-popup {
+    right: 20px;
+    bottom: 20px;
+    width: calc(100% - 40px);
+  }
 }
 /* RESPONSIVE MOBILE */
 @media only screen and (max-width: 767px), only screen and (max-device-width: 767px) {
@@ -3748,8 +3847,9 @@ input::-moz-focus-inner, input::-moz-focus-outer {
   }
 
   .footer .scroll-top {
-    right: auto;
     left: 15px;
+    bottom: 15px;
+    padding: 12px 20px;
   }
 
   .footer .footer-bottom ul {
@@ -3759,5 +3859,23 @@ input::-moz-focus-inner, input::-moz-focus-outer {
   .footer .footer-bottom ul li {
     margin-left: 0;
     margin-right: 10px;
+  }
+
+  .cta-popup {
+    left: 15px;
+    right: 15px;
+    bottom: 20px;
+    width: auto;
+    padding: 26px;
+    border-radius: 20px;
+  }
+
+  .cta-popup h3 {
+    font-size: 24px;
+  }
+
+  .cta-popup .cta-popup__call {
+    width: 100%;
+    padding: 12px 18px;
   }
 }

--- a/index.html
+++ b/index.html
@@ -357,7 +357,7 @@
   </div>
 </section>
 <!-- end content-section -->
-<section class="content-section no-spacing">
+<section class="content-section no-spacing" id="notre-histoire">
   <div class="container">
     <div class="row align-items-center">
       <div class="col-12">
@@ -963,10 +963,19 @@
   </div>
   <!-- end container -->
 
-  <a href="#" class="scroll-top"><i class="lni lni-arrow-up"></i> <small>Haut de page</small></a>
+  <a href="#" class="scroll-top" aria-label="Retour en haut de la page"><i class="lni lni-arrow-up"></i> <small>Retour en haut</small></a>
   <!-- end scroll-top -->
 </footer>
 <!-- end footer -->
+
+<div class="cta-popup-backdrop" aria-hidden="true"></div>
+<section class="cta-popup" role="dialog" aria-modal="true" aria-labelledby="cta-popup-title" aria-describedby="cta-popup-text" aria-hidden="true" tabindex="-1">
+  <button type="button" class="cta-popup__close" aria-label="Fermer la fenêtre d'appel">&times;</button>
+  <h3 id="cta-popup-title">Prêt à donner vie à votre projet&nbsp;?</h3>
+  <p id="cta-popup-text">Nos conseillers RenoGo sont disponibles pour vous guider et planifier vos travaux dès maintenant.</p>
+  <a class="cta-popup__call" href="tel:+33232000005">Appeler RenoGo au 02&nbsp;32&nbsp;00&nbsp;00&nbsp;05</a>
+</section>
+
 
 <div id="sales-specialist-form">
   <form aria-label="Demande de rappel RenoGo">

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -54,6 +54,85 @@
     });
 
 
+    // CTA POPUP
+    var $ctaPopup = $('.cta-popup');
+    var $ctaBackdrop = $('.cta-popup-backdrop');
+    var histoireSection = document.querySelector('#notre-histoire');
+    var popupDismissed = false;
+
+    try {
+      popupDismissed = sessionStorage.getItem('ctaPopupDismissed') === 'true';
+    } catch (error) {
+      popupDismissed = false;
+    }
+
+    function openCtaPopup() {
+      if (popupDismissed) {
+        return;
+      }
+
+      if ($ctaPopup.length && !$ctaPopup.hasClass('is-visible')) {
+        $ctaPopup.addClass('is-visible').attr('aria-hidden', 'false');
+        $ctaBackdrop.addClass('is-visible').attr('aria-hidden', 'false');
+        var $closeButton = $ctaPopup.find('.cta-popup__close');
+        if ($closeButton.length) {
+          $closeButton.trigger('focus');
+        }
+      }
+    }
+
+    function closeCtaPopup() {
+      if ($ctaPopup.length) {
+        $ctaPopup.removeClass('is-visible').attr('aria-hidden', 'true');
+        $ctaBackdrop.removeClass('is-visible').attr('aria-hidden', 'true');
+        popupDismissed = true;
+        try {
+          sessionStorage.setItem('ctaPopupDismissed', 'true');
+        } catch (error) {
+          // Ignore storage errors (private mode, etc.)
+        }
+      }
+    }
+
+    if ($ctaPopup.length && $ctaBackdrop.length) {
+      $ctaPopup.find('.cta-popup__close').on('click', function () {
+        closeCtaPopup();
+      });
+
+      $ctaBackdrop.on('click', function () {
+        closeCtaPopup();
+      });
+
+      $(document).on('keydown.ctaPopup', function (event) {
+        if (event.key === 'Escape' && $ctaPopup.hasClass('is-visible')) {
+          closeCtaPopup();
+        }
+      });
+    }
+
+    if (histoireSection && !popupDismissed && $ctaPopup.length && $ctaBackdrop.length) {
+      if ('IntersectionObserver' in window) {
+        var histoireObserver = new IntersectionObserver(function (entries, observer) {
+          entries.forEach(function (entry) {
+            if (entry.isIntersecting) {
+              openCtaPopup();
+              observer.disconnect();
+            }
+          });
+        }, { threshold: 0.5 });
+
+        histoireObserver.observe(histoireSection);
+      } else {
+        $(window).on('scroll.ctaPopup', function () {
+          if ($(window).scrollTop() + $(window).height() >= $(histoireSection).offset().top) {
+            openCtaPopup();
+            $(window).off('scroll.ctaPopup');
+          }
+        });
+      }
+    }
+
+
     // PAGE TRANSITION
     $('body a').on('click', function (e) {
       if (typeof $(this).data('fancybox') == 'undefined') {

--- a/leadership.html
+++ b/leadership.html
@@ -461,9 +461,9 @@
     <!-- end row --> 
   </div>
   <!-- end container --> 
-	<a href="#" class="scroll-top"><i class="lni lni-arrow-up"></i>
-	<small>Scroll Up</small>
-	</a>
+        <a href="#" class="scroll-top" aria-label="Retour en haut de la page"><i class="lni lni-arrow-up"></i>
+        <small>Retour en haut</small>
+        </a>
 	<!-- end scroll-top -->
 </footer>
 <!-- end footer --> 

--- a/news-sing.html
+++ b/news-sing.html
@@ -311,9 +311,9 @@
     <!-- end row --> 
   </div>
   <!-- end container --> 
-	<a href="#" class="scroll-top"><i class="lni lni-arrow-up"></i>
-	<small>Scroll Up</small>
-	</a>
+        <a href="#" class="scroll-top" aria-label="Retour en haut de la page"><i class="lni lni-arrow-up"></i>
+        <small>Retour en haut</small>
+        </a>
 	<!-- end scroll-top -->
 </footer>
 <!-- end footer --> 

--- a/news.html
+++ b/news.html
@@ -512,7 +512,7 @@
     <!-- end row -->
   </div>
   <!-- end container -->
-        <a href="#" class="scroll-top"><i class="lni lni-arrow-up"></i>
+        <a href="#" class="scroll-top" aria-label="Retour en haut de la page"><i class="lni lni-arrow-up"></i>
         <small>Retour en haut</small>
         </a>
         <!-- end scroll-top -->

--- a/offices.html
+++ b/offices.html
@@ -270,9 +270,9 @@ Rome Italy</p>
     <!-- end row --> 
   </div>
   <!-- end container --> 
-	<a href="#" class="scroll-top"><i class="lni lni-arrow-up"></i>
-	<small>Scroll Up</small>
-	</a>
+        <a href="#" class="scroll-top" aria-label="Retour en haut de la page"><i class="lni lni-arrow-up"></i>
+        <small>Retour en haut</small>
+        </a>
 	<!-- end scroll-top -->
 </footer>
 <!-- end footer --> 

--- a/our-history.html
+++ b/our-history.html
@@ -306,9 +306,9 @@
     <!-- end row --> 
   </div>
   <!-- end container --> 
-	<a href="#" class="scroll-top"><i class="lni lni-arrow-up"></i>
-	<small>Scroll Up</small>
-	</a>
+        <a href="#" class="scroll-top" aria-label="Retour en haut de la page"><i class="lni lni-arrow-up"></i>
+        <small>Retour en haut</small>
+        </a>
 	<!-- end scroll-top -->
 </footer>
 <!-- end footer --> 

--- a/project-single.html
+++ b/project-single.html
@@ -395,9 +395,9 @@
     <!-- end row --> 
   </div>
   <!-- end container --> 
-	<a href="#" class="scroll-top"><i class="lni lni-arrow-up"></i>
-	<small>Scroll Up</small>
-	</a>
+        <a href="#" class="scroll-top" aria-label="Retour en haut de la page"><i class="lni lni-arrow-up"></i>
+        <small>Retour en haut</small>
+        </a>
 	<!-- end scroll-top -->
 </footer>
 <!-- end footer --> 

--- a/projects.html
+++ b/projects.html
@@ -527,7 +527,7 @@
       <!-- end row -->
     </div>
     <!-- end container -->
-    <a href="#" class="scroll-top"><i class="lni lni-arrow-up"></i> <small>Retour en haut</small> </a>
+    <a href="#" class="scroll-top" aria-label="Retour en haut de la page"><i class="lni lni-arrow-up"></i> <small>Retour en haut</small> </a>
     <!-- end scroll-top -->
   </footer>
   <!-- end footer -->

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -829,8 +829,9 @@ a:hover{text-decoration: underline; color:$color-dark;}
 
 /* FOOTER */
 .footer{width: 100%; display: block; background-color:$color-dark; position: relative; padding-top: 80px; color: #fff;
-	.scroll-top{width: 100px; background: $color-main; position: absolute; right: 30px; top: -30px; z-index: 1; color: $color-dark; text-align: center; padding: 15px 0;
-		small{width: 100%; display: block;}}
+        .scroll-top{background: $color-main; position: fixed; left: 30px; bottom: 30px; right: auto; top: auto; z-index: 1000; color: $color-dark; padding: 14px 24px; border-radius: 40px; display: inline-flex; align-items: center; gap: 10px; box-shadow: 0 20px 40px rgba(0,0,0,0.2); font-weight: 600; letter-spacing: 0.05em; text-transform: uppercase;
+                i{font-size: 18px;}
+                small{width: auto; display: inline;}}
 	.widget-title{width: 100%; display: block; margin-bottom: 20px; font-weight: 600; opacity: 0.7; letter-spacing: 2px;}
 	address{width: 100%; display: block; margin: 0;
 		p{width: 100%; display: block;}
@@ -845,6 +846,20 @@ a:hover{text-decoration: underline; color:$color-dark;}
 			li{display: inline-block; margin-left: 20px; padding: 0; list-style: none;
 				a{opacity: 0.7; font-size: 13px; color: #fff;
 					&:hover{opacity: 1; text-decoration-color: $color-main;}}}}}}
+
+
+
+
+.cta-popup-backdrop{position: fixed; left: 0; top: 0; width: 100%; height: 100%; background: rgba(11,11,11,0.55); opacity: 0; pointer-events: none; transition: opacity .35s ease; z-index: 998;
+        &.is-visible{opacity: 1; pointer-events: auto;}}
+
+.cta-popup{position: fixed; right: 40px; bottom: 40px; max-width: 360px; width: calc(100% - 80px); background: #fff; color: $color-dark; padding: 32px; border-radius: 24px; box-shadow: 0 35px 55px rgba(11,11,11,0.25); opacity: 0; pointer-events: none; transform: translateY(30px); transition: all .35s ease; z-index: 999; line-height: 1.6;
+        &.is-visible{opacity: 1; pointer-events: auto; transform: translateY(0);}
+        h3{font-size: 28px; line-height: 1.3; margin-bottom: 12px;}
+        p{margin-bottom: 24px;}
+        .cta-popup__close{position: absolute; right: 18px; top: 14px; background: transparent; border: none; font-size: 28px; line-height: 1; color: $color-dark; cursor: pointer; padding: 0;}
+        .cta-popup__call{display: inline-flex; align-items: center; justify-content: center; gap: 10px; background: $color-main; color: $color-dark; padding: 14px 22px; border-radius: 999px; font-weight: 700; letter-spacing: 0.05em; text-transform: uppercase; text-decoration: none;
+                &:hover{text-decoration: none; color: $color-dark; background: lighten($color-main, 6%);}}}
 
 
 /* SALES SPECIALIST FORM */
@@ -942,7 +957,8 @@ input::-moz-focus-inner, input::-moz-focus-outer {  border: 0;}
 	.logo-item{margin: 15px 0;}
 	.col-lg-5 .recent-news{margin-bottom: 30px;}
 	.footer-bar .sales-representive{margin-left: 0; margin-top: 30px;}
-	.footer address{margin-bottom: 50px;}
+        .footer address{margin-bottom: 50px;}
+        .cta-popup{right: 20px; bottom: 20px; width: calc(100% - 40px);}
 }
 
 
@@ -985,10 +1001,13 @@ input::-moz-focus-inner, input::-moz-focus-outer {  border: 0;}
 	.calculator .form{padding: 30px;}
 	.footer-bar h2{font-size: 40px;}
 	.footer-bar .sales-representive{line-height: inherit;}
-	.footer-bar .sales-representive b{color: $color-main;}
-	.footer-bar .sales-representive b:before{display: none;}
-	.footer-bar .sales-representive figure{width: 100%;}
-	.footer .scroll-top{right: auto; left: 15px;}
-	.footer .footer-bottom ul{float: left;}
-	.footer .footer-bottom ul li{ margin-left: 0; margin-right: 10px;}
+        .footer-bar .sales-representive b{color: $color-main;}
+        .footer-bar .sales-representive b:before{display: none;}
+        .footer-bar .sales-representive figure{width: 100%;}
+        .footer .scroll-top{left: 15px; bottom: 15px; padding: 12px 20px;}
+        .footer .footer-bottom ul{float: left;}
+        .footer .footer-bottom ul li{ margin-left: 0; margin-right: 10px;}
+        .cta-popup{left: 15px; right: 15px; bottom: 20px; width: auto; padding: 26px; border-radius: 20px;}
+        .cta-popup h3{font-size: 24px;}
+        .cta-popup .cta-popup__call{width: 100%; padding: 12px 18px;}
 }

--- a/services.html
+++ b/services.html
@@ -560,7 +560,7 @@
     <!-- end row -->
   </div>
   <!-- end container -->
-  <a href="#" class="scroll-top"><i class="lni lni-arrow-up"></i> <small>Retour en haut</small> </a>
+  <a href="#" class="scroll-top" aria-label="Retour en haut de la page"><i class="lni lni-arrow-up"></i> <small>Retour en haut</small> </a>
   <!-- end scroll-top -->
 </footer>
 <!-- end footer -->


### PR DESCRIPTION
## Summary
- ajoute une fenêtre modale d’appel qui s’affiche à l’arrivée dans la section « Notre histoire » de la page d’accueil
- applique le style et les comportements nécessaires (fermeture, accessibilité, responsive) pour la popup et le bouton flottant
- harmonise le libellé français et la position du bouton « Retour en haut » sur toutes les pages HTML

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68d7ebe12764832ea3d418be7127c032