### PR TITLE
Add home navigation links across site pages

### DIFF
--- a/about-company.html
+++ b/about-company.html
@@ -176,6 +176,7 @@
     <div class="show-mobile">
       <nav class="site-menu" aria-label="Menu principal mobile">
         <ul>
+          <li><a href="index.html">Accueil</a></li>
           <li class="has-children">
          <a href="about-company.html">À propos</a></a>
           </li>
@@ -205,6 +206,7 @@
 
     <div class="site-menu" aria-label="Menu principal">
       <ul>
+        <li><a href="index.html">Accueil</a></li>
         <li class="has-children">
           <a href="about-company.html">À propos</a>
         </li>

--- a/certificates.html
+++ b/certificates.html
@@ -85,6 +85,7 @@
     <!-- end languages -->
     <div class="site-menu">
       <ul>
+        <li><a href="index.html">Home</a></li>
         <li><a href="#">Consto</a><i class="lni lni-chevron-down-circle"></i>
 		  <ul>
 				<li><a href="about-company.html">About Company</a></li>
@@ -123,6 +124,7 @@
     <!-- end languages -->
     <div class="site-menu">
       <ul>
+        <li><a href="index.html">Home</a></li>
         <li><a href="#">Consto</a>
 		  <ul>
 				<li><a href="about-company.html">About Company</a></li>

--- a/contact.html
+++ b/contact.html
@@ -176,6 +176,7 @@
     <div class="show-mobile">
       <nav class="site-menu" aria-label="Menu principal mobile">
         <ul>
+          <li><a href="index.html">Accueil</a></li>
           <li class="has-children">
          <a href="about-company.html">À propos</a></a>
           </li>
@@ -205,6 +206,7 @@
 
     <div class="site-menu" aria-label="Menu principal">
       <ul>
+        <li><a href="index.html">Accueil</a></li>
         <li class="has-children">
           <a href="about-company.html">À propos</a>
         </li>

--- a/core-values.html
+++ b/core-values.html
@@ -85,6 +85,7 @@
     <!-- end languages -->
     <div class="site-menu">
       <ul>
+        <li><a href="index.html">Home</a></li>
         <li><a href="#">Consto</a><i class="lni lni-chevron-down-circle"></i>
 		  <ul>
 				<li><a href="about-company.html">About Company</a></li>
@@ -123,6 +124,7 @@
     <!-- end languages -->
     <div class="site-menu">
       <ul>
+        <li><a href="index.html">Home</a></li>
         <li><a href="#">Consto</a>
 		  <ul>
 				<li><a href="about-company.html">About Company</a></li>

--- a/index.html
+++ b/index.html
@@ -176,6 +176,7 @@
     <div class="show-mobile">
       <nav class="site-menu" aria-label="Menu principal mobile">
         <ul>
+          <li><a href="index.html">Accueil</a></li>
           <li class="has-children">
          <a href="about-company.html">À propos</a></a>
           </li>
@@ -205,6 +206,7 @@
 
     <div class="site-menu" aria-label="Menu principal">
       <ul>
+        <li><a href="index.html">Accueil</a></li>
         <li class="has-children">
           <a href="about-company.html">À propos</a>
         </li>

--- a/leadership.html
+++ b/leadership.html
@@ -85,6 +85,7 @@
     <!-- end languages -->
     <div class="site-menu">
       <ul>
+        <li><a href="index.html">Home</a></li>
         <li><a href="#">Consto</a><i class="lni lni-chevron-down-circle"></i>
 		  <ul>
 				<li><a href="about-company.html">About Company</a></li>
@@ -123,6 +124,7 @@
     <!-- end languages -->
     <div class="site-menu">
       <ul>
+        <li><a href="index.html">Home</a></li>
         <li><a href="#">Consto</a>
 		  <ul>
 				<li><a href="about-company.html">About Company</a></li>

--- a/news-sing.html
+++ b/news-sing.html
@@ -85,6 +85,7 @@
     <!-- end languages -->
     <div class="site-menu">
       <ul>
+        <li><a href="index.html">Home</a></li>
         <li><a href="#">Consto</a><i class="lni lni-chevron-down-circle"></i>
 		  <ul>
 				<li><a href="about-company.html">About Company</a></li>
@@ -123,6 +124,7 @@
     <!-- end languages -->
     <div class="site-menu">
       <ul>
+        <li><a href="index.html">Home</a></li>
         <li><a href="#">Consto</a>
 		  <ul>
 				<li><a href="about-company.html">About Company</a></li>

--- a/news.html
+++ b/news.html
@@ -176,6 +176,7 @@
     <div class="show-mobile">
       <nav class="site-menu" aria-label="Menu principal mobile">
         <ul>
+          <li><a href="index.html">Accueil</a></li>
           <li class="has-children">
          <a href="about-company.html">À propos</a></a>
           </li>
@@ -203,6 +204,7 @@
 
     <div class="site-menu" aria-label="Menu principal">
       <ul>
+        <li><a href="index.html">Accueil</a></li>
         <li class="has-children">
           <a href="about-company.html">À propos</a>
         </li>

--- a/offices.html
+++ b/offices.html
@@ -85,6 +85,7 @@
     <!-- end languages -->
     <div class="site-menu">
       <ul>
+        <li><a href="index.html">Home</a></li>
         <li><a href="#">Consto</a><i class="lni lni-chevron-down-circle"></i>
 		  <ul>
 				<li><a href="about-company.html">About Company</a></li>
@@ -123,6 +124,7 @@
     <!-- end languages -->
     <div class="site-menu">
       <ul>
+        <li><a href="index.html">Home</a></li>
         <li><a href="#">Consto</a>
 		  <ul>
 				<li><a href="about-company.html">About Company</a></li>

--- a/our-history.html
+++ b/our-history.html
@@ -85,6 +85,7 @@
     <!-- end languages -->
     <div class="site-menu">
       <ul>
+        <li><a href="index.html">Home</a></li>
         <li><a href="#">Consto</a><i class="lni lni-chevron-down-circle"></i>
 		  <ul>
 				<li><a href="about-company.html">About Company</a></li>
@@ -123,6 +124,7 @@
     <!-- end languages -->
     <div class="site-menu">
       <ul>
+        <li><a href="index.html">Home</a></li>
         <li><a href="#">Consto</a>
 		  <ul>
 				<li><a href="about-company.html">About Company</a></li>

--- a/project-single.html
+++ b/project-single.html
@@ -85,6 +85,7 @@
     <!-- end languages -->
     <div class="site-menu">
       <ul>
+        <li><a href="index.html">Home</a></li>
         <li><a href="#">Consto</a><i class="lni lni-chevron-down-circle"></i>
 		  <ul>
 				<li><a href="about-company.html">About Company</a></li>
@@ -123,6 +124,7 @@
     <!-- end languages -->
     <div class="site-menu">
       <ul>
+        <li><a href="index.html">Home</a></li>
         <li><a href="#">Consto</a>
 		  <ul>
 				<li><a href="about-company.html">About Company</a></li>

--- a/projects.html
+++ b/projects.html
@@ -176,6 +176,7 @@
     <div class="show-mobile">
       <nav class="site-menu" aria-label="Menu principal mobile">
         <ul>
+          <li><a href="index.html">Accueil</a></li>
           <li class="has-children">
          <a href="about-company.html">À propos</a></a>
           </li>
@@ -205,6 +206,7 @@
 
     <div class="site-menu" aria-label="Menu principal">
       <ul>
+        <li><a href="index.html">Accueil</a></li>
         <li class="has-children">
           <a href="about-company.html">À propos</a>
         </li>

--- a/services.html
+++ b/services.html
@@ -176,6 +176,7 @@
     <div class="show-mobile">
       <nav class="site-menu" aria-label="Menu principal mobile">
         <ul>
+          <li><a href="index.html">Accueil</a></li>
           <li class="has-children">
          <a href="about-company.html">À propos</a></a>
           </li>
@@ -205,6 +206,7 @@
 
     <div class="site-menu" aria-label="Menu principal">
       <ul>
+        <li><a href="index.html">Accueil</a></li>
         <li class="has-children">
           <a href="about-company.html">À propos</a>
         </li>


### PR DESCRIPTION
## Summary
- add Home/Accueil navigation link to both desktop and mobile menus across all HTML pages so visitors can return to the homepage

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d810077690832e9b388e95d0f623f9