### PR TITLE
Revert recent SEO content updates

### DIFF
--- a/about-company.html
+++ b/about-company.html
@@ -6,8 +6,8 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <!-- Primary SEO -->
-  <title>RenoGo • Rénovation, maintenance et efficacité énergétique en Normandie & Île-de-France</title>
-  <meta name="description" content="RenoGo accompagne entreprises et particuliers en Normandie et Île-de-France : rénovation de bureaux, modernisation d’habitats, maintenance multi-technique et solutions basse consommation.">
+  <title>RenoGo • Rénovation intérieure & amélioration de l’habitat en France</title>
+  <meta name="description" content="RenoGo rénove et transforme appartements et maisons : cuisines, salles de bain, isolation, électricité, peinture. Devis rapide, travaux qualitatifs, livrés à temps.">
   <link rel="canonical" href="https://www.renogo.fr/">
 
   <!-- Indexing -->
@@ -29,8 +29,8 @@
   <meta property="og:locale" content="fr_FR">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="RenoGo">
-  <meta property="og:title" content="RenoGo • Rénovation et maintenance professionnelles">
-  <meta property="og:description" content="Solutions clés en main pour bureaux et habitats : rénovation rapide, maintenance fiable, performance énergétique durable.">
+  <meta property="og:title" content="RenoGo • Rénovation intérieure & amélioration de l’habitat">
+  <meta property="og:description" content="Cuisine, salle de bain, peinture, isolation et plus. Devis rapide, travaux maîtrisés.">
   <meta property="og:url" content="https://www.renogo.fr/">
   <meta property="og:image" content="https://www.renogo.fr/assets/og/renogo-cover.jpg">
   <meta property="og:image:width" content="1200">
@@ -39,8 +39,8 @@
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@renogo">
-  <meta name="twitter:title" content="RenoGo • Rénovation et maintenance professionnelles">
-  <meta name="twitter:description" content="RenoGo modernise bureaux et maisons en Normandie & Île-de-France : confort, ergonomie, efficacité énergétique.">
+  <meta name="twitter:title" content="RenoGo • Rénovation intérieure & amélioration de l’habitat">
+  <meta name="twitter:description" content="Rénovation d’appartements et maisons en France. Devis rapide, délais tenus.">
   <meta name="twitter:image" content="https://www.renogo.fr/assets/og/renogo-cover.jpg">
 
   <!-- Organization -->
@@ -75,7 +75,7 @@
     "url": "https://www.renogo.fr/",
     "logo": "https://www.renogo.fr/assets/logo/renogo-logo.svg",
     "image": "https://www.renogo.fr/assets/og/renogo-cover.jpg",
-    "description": "Rénovation de bureaux et logements, maintenance multi-technique, efficacité énergétique et aménagements connectés.",
+    "description": "Rénovation intérieure d’appartements et maisons : cuisines, salles de bain, isolation, électricité, peinture.",
     "telephone": "+33-1-23-45-67-89",
     "areaServed": "FR",
     "priceRange": "€€",
@@ -144,10 +144,10 @@
 
     <div class="hide-mobile">
       <p>
-        RenoGo pilote vos projets de rénovation et de maintenance en Normandie &amp; Île-de-France :
-        <u>électricité &amp; éclairage</u>, <u>peinture &amp; sols</u>, <u>plomberie &amp; CVC</u>,
-        <u>jardinage &amp; aménagement paysager</u> et <u>domotique / smart building</u>.
-        Des chantiers propres, des délais tenus et un suivi de proximité.
+        RenoGo accompagne vos projets de rénovation et d’entretien en Normandie :
+        <u>électricité & éclairage</u>, <u>peinture & sols</u>, <u>cloisons & isolation</u>,
+        <u>jardinage & aménagement paysager</u>, ainsi que <u>domotique / maison intelligente</u>.
+        Des chantiers propres, des délais tenus, un suivi de proximité.
       </p>
 
       <figure class="gallery">
@@ -235,7 +235,7 @@
 <header class="page-header">
   <div class="container">
     <h1>À PROPOS</h1>
-          <h6>Votre partenaire normand et francilien pour des bureaux productifs et des habitats durables.</h6>
+          <h6>Une équipe proche des territoires normands, dédiée aux intérieurs vivants et aux extérieurs verdoyants.</h6>
           <ul>
                 <li><a href="#">ACCUEIL</a></li>
                 <li>À PROPOS</li>
@@ -250,20 +250,20 @@
                 <div class="col-12">
                          <div class="section-title text-left">
           <h6>NOTRE HISTOIRE</h6>
-          <h2>RenoGo, trait d’union entre Paris et la Normandie</h2>
+          <h2>RenoGo, passerelle entre Paris et la Normandie</h2>
         </div>
         <!-- end section-title -->
                 </div>
                 <!-- end col-12 -->
                 <div class="col-md-7">
                 <figure><img src="images/salon.jpg" alt="Équipe RenoGo en intervention"></figure>
-                        <p>RenoGo est née d’un besoin très concret : aider une PME parisienne à moderniser ses bureaux tout en rénovant la maison familiale à Bayeux. Cette double mission nous a révélé l’urgence d’un interlocuteur unique capable d’orchestrer la rénovation de bâtiments professionnels et résidentiels entre l’Île-de-France et la Normandie. Depuis, nous accompagnons les dirigeants, facility managers et propriétaires dans chaque transformation stratégique.</p>
-                        <p>Nous combinons l’exigence des environnements corporate et la chaleur des projets de vie. Bureaux flexibles pour co-working à La Défense, modernisation énergétique d’un manoir à Deauville, maintenance multi-technique pour des cliniques à Rouen : notre équipe mêle ingénierie, design et services de proximité pour livrer des espaces performants, confortables et responsables.</p>
+                        <p>Tout est parti d'un appartement parisien transformé pour un couple originaire du Calvados. Touchés par notre sens du détail et notre écoute, ils ont soufflé à leurs proches l'idée de nous confier leurs résidences secondaires. De fil en aiguille, RenoGo a suivi la route des falaises d'Étretat aux marais du Cotentin pour devenir la référence de la rénovation clé en main en Normandie.</p>
+                        <p>À chaque chantier, nous conjugons savoir-faire artisanal et technologies intelligentes : éclairage connecté à Honfleur, isolation biosourcée à Caen, jardins comestibles à Deauville… Notre promesse reste la même : révéler le potentiel des maisons et bureaux normands en respectant leur âme, leurs matériaux et les cycles naturels du territoire.</p>
                 </div>
                 <!-- end col-7 -->
                 <div class="col-md-5">
                 <figure><img src="images/jardin-a-propos.jpg" alt="Services RenoGo"></figure>
-                        <p>Implantés au cœur du 8ᵉ arrondissement et ancrés dans chaque département normand, nous fédérons des artisans certifiés RGE, des spécialistes CVC, des ergonomes et des chefs de projet digitaux. Cette task force nous permet de piloter des chantiers rapides, sécurisés et maîtrisés, qu’il s’agisse d’un open space à Saint-Denis ou d’une longère à Lisieux.</p>
+                        <p>Implantés à Paris, nous avons constitué un réseau d'artisans locaux certifiés RGE, paysagistes, électriciens et peintres capables d'intervenir rapidement dans chaque département normand. Cette alliance nous permet d'assurer la même qualité RenoGo, de Granville à Dieppe.</p>
                 </div>
                 <!-- end col-5 -->
           </div>
@@ -277,8 +277,8 @@
     <div class="row">
       <div class="col-lg-3 col-md-6">
         <div class="counter-box"> <span class="odometer" data-count="98" data-status="yes">0</span> <span class="value">%</span>
-          <h6>Clients ambassadeurs</h6>
-          <p>SME, copropriétés et familles nous recommandent après chaque chantier livré de Caen à Boulogne-Billancourt.</p>
+          <h6>Clients enchantés</h6>
+          <p>Satisfaction mesurée après chaque livraison de chantier sur Caen, Rouen et Le Havre.</p>
         </div>
         <!-- end counter-box -->
       </div>
@@ -286,23 +286,23 @@
       <div class="col-lg-3 col-md-6">
         <div class="counter-box"> <span class="odometer" data-count="365" data-status="yes">0</span> <span class="value">j</span>
           <h6>Assistance continue</h6>
-          <p>Hotline et interventions planifiées 365 jours par an pour sécuriser vos équipements critiques.</p>
+          <p>Maintenance préventive et corrective disponible toute l'année pour vos bâtiments.</p>
         </div>
         <!-- end counter-box -->
       </div>
       <!-- end col-3 -->
       <div class="col-lg-3 col-md-6">
         <div class="counter-box"> <span class="odometer" data-count="450" data-status="yes">0</span> <span class="value">m²</span>
-          <h6>Espaces métamorphosés</h6>
-          <p>Open spaces, salles de réunion, cuisines familiales : plus de 450 m² repensés chaque mois.</p>
+          <h6>Espaces rénovés chaque mois</h6>
+          <p>De la peinture intérieure aux sols sur mesure, nous optimisons vos surfaces.</p>
         </div>
         <!-- end counter-box -->
       </div>
       <!-- end col-3 -->
       <div class="col-lg-3 col-md-6">
         <div class="counter-box"> <span class="odometer" data-count="120" data-status="yes">0</span> <span class="value">+</span>
-          <h6>Sites maintenus</h6>
-          <p>Contrats actifs sur bureaux, résidences et jardins pour garantir une performance durable.</p>
+          <h6>Projets paysagers</h6>
+          <p>Potagers, terrasses bois et jardins zen qui prolongent la vie dehors même en bord de mer.</p>
         </div>
         <!-- end counter-box -->
       </div>
@@ -325,7 +325,7 @@
       </div>
       <!-- end col-7 -->
       <div class="col-lg-5">
-        <p>Notre méthode capitalise sur l’ingénierie de chantier, la data de suivi et le pilotage multi-sites. Elle garantit une exécution fluide pour vos bureaux comme pour vos résidences secondaires.</p>
+        <p>Notre portfolio reflète trente ans d'expérience cumulée, des investissements réguliers dans les innovations vertes et une culture du service qui place votre confort au cœur du projet.</p>
       </div>
       <!-- end col-5 -->
                 <div class="col-lg-4">
@@ -334,8 +334,8 @@
                         <div class="content">
                                 <span>01.</span>
                         <figure class="icon"><img src="images/icon01.png" alt="Icône écoute"></figure>
-                                <h6>Diagnostic terrain & digital</h6>
-                                <p>Audit énergétique, analyse ergonomique et relevés BIM pour dessiner des scénarios travaux sur-mesure.</p>
+                                <h6>Diagnostic sur site</h6>
+                                <p>Visite technique, thermographie et relevés lumière pour imaginer la solution la plus adaptée à votre bien normand.</p>
                         </div>
                                 <!-- end content -->
                         </div>
@@ -348,8 +348,8 @@
                         <div class="content">
                                 <span>02.</span>
                         <figure class="icon"><img src="images/icon02.png" alt="Icône organisation"></figure>
-                                <h6>Planification agile</h6>
-                                <p>Planning phasé pour limiter l’arrêt d’activité, sélection de matériaux bas carbone et reporting en ligne.</p>
+                                <h6>Planification harmonieuse</h6>
+                                <p>Coordination des corps de métiers, sélection de matériaux durables et suivi numérique accessible en temps réel.</p>
                         </div>
                                 <!-- end content -->
                         </div>
@@ -363,7 +363,7 @@
                                 <span>03.</span>
                         <figure class="icon"><img src="images/icon03.png" alt="Icône partenariat"></figure>
                                 <h6>Suivi durable</h6>
-                                <p>Contrôles connectés, contrats de maintenance évolutifs et coaching des équipes occupants.</p>
+                                <p>Contrôles annuels, conseils d'entretien saisonniers et hotline pour anticiper chaque besoin.</p>
                         </div>
                                 <!-- end content -->
                         </div>
@@ -414,9 +414,9 @@
     <div class="row">
       <div class="col-12">
         <div class="video-box"> <a href="videos/video01.mp4" data-fancybox data-width="640" data-height="360" class="play-btn"><i class="lni lni-play"></i></a>
-          <h6>VISITE D'UN DOUBLE CHANTIER</h6>
-          <h2>Suivez la transformation d’un siège social et d’une villa normande</h2>
-          <p>Découvrez comment nos équipes coordonnent en parallèle un plateau de bureaux à Nanterre et une maison familiale à Cabourg : phasage sans interruption d’activité, isolation biosourcée, smart lighting et terrasses paysagées.</p>
+          <h6>VISITE D'UN CHANTIER</h6>
+          <h2>Découvrez comment RenoGo redonne vie aux demeures normandes</h2>
+          <p>Plongez dans un projet complet mené à Cabourg : isolation acoustique, peinture aux pigments naturels, terrasse bois avec éclairage connecté et serre urbaine pour aromatiques.</p>
         </div>
         <!-- end video-box -->
       </div>
@@ -427,36 +427,36 @@
       <div class="col-lg-8">
         <div class="accordion" id="accordion" role="tablist">
             <div class="card">
-              <div class="card-header" role="tab" id="headingOne"> <a data-toggle="collapse" href="#collapseOne" aria-expanded="true" aria-controls="collapseOne"> Quels territoires RenoGo couvre-t-elle ? <i class="lni lni-arrow-right"></i></a> </div>
+              <div class="card-header" role="tab" id="headingOne"> <a data-toggle="collapse" href="#collapseOne" aria-expanded="true" aria-controls="collapseOne"> Quels services RenoGo propose-t-elle en Normandie ? <i class="lni lni-arrow-right"></i></a> </div>
               <div id="collapseOne" class="collapse show" role="tabpanel" aria-labelledby="headingOne" data-parent="#accordion">
-                <div class="card-body"> Nous accompagnons les entreprises et les particuliers en Île-de-France et en Normandie : Paris, Nanterre, Saint-Denis, Rouen, Caen, Le Havre, Deauville… Notre réseau local garantit des interventions rapides et coordonnées dans chaque département.</div>
+                <div class="card-body"> Nous intervenons sur le jardinage et l'aménagement paysager, les travaux d'électricité et de domotique, la peinture intérieure et extérieure, les cloisons sèches et l'isolation ainsi que la pose de revêtements de sol adaptés aux climats normands.</div>
                 <!-- end card-body -->
               </div>
               <!-- end collapse -->
             </div>
             <!-- end card -->
             <div class="card">
-              <div class="card-header" role="tab" id="headingTwo"> <a class="collapsed" data-toggle="collapse" href="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo"> Comment RenoGo sécurise-t-elle délais et budgets ? <i class="lni lni-arrow-right"></i></a> </div>
+              <div class="card-header" role="tab" id="headingTwo"> <a class="collapsed" data-toggle="collapse" href="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo"> Comment garantissez-vous la qualité des chantiers ? <i class="lni lni-arrow-right"></i></a> </div>
               <div id="collapseTwo" class="collapse" role="tabpanel" aria-labelledby="headingTwo" data-parent="#accordion">
-                <div class="card-body"> Chaque programme est géré par un chef de projet dédié qui consolide planning, achats et ressources dans notre plateforme digitale. Vous disposez d’un tableau de bord en temps réel, de points hebdomadaires et d’un plan d’actions correctif si nécessaire.</div>
+                <div class="card-body"> Chaque projet est suivi par un chef de chantier RenoGo, épaulé par des artisans certifiés RGE et Qualifelec. Nous utilisons un carnet de chantier numérique partagé avec vous pour valider chaque étape, du choix des matériaux à la réception.</div>
                 <!-- end card-body -->
               </div>
               <!-- end collapse -->
             </div>
             <!-- end card -->
             <div class="card">
-              <div class="card-header" role="tab" id="headingThree"> <a class="collapsed" data-toggle="collapse" href="#collapseThree" aria-expanded="false" aria-controls="collapseThree"> Quelles solutions d’efficacité énergétique proposez-vous ? <i class="lni lni-arrow-right"></i></a> </div>
+              <div class="card-header" role="tab" id="headingThree"> <a class="collapsed" data-toggle="collapse" href="#collapseThree" aria-expanded="false" aria-controls="collapseThree"> Intervenez-vous sur les résidences secondaires ? <i class="lni lni-arrow-right"></i></a> </div>
               <div id="collapseThree" class="collapse" role="tabpanel" aria-labelledby="headingThree" data-parent="#accordion">
-                <div class="card-body"> Isolation biosourcée, régulation intelligente, relamping LED, monitoring énergétique, gestion HVAC : nous déployons des solutions certifiées pour réduire vos consommations et bénéficier des aides disponibles.</div>
+                <div class="card-body"> Oui, c'est même notre spécialité. Nous gérons les clés, organisons les rendez-vous de chantier avec vos voisins et pouvons équiper votre maison de systèmes intelligents pour surveiller l'humidité, le chauffage et l'arrosage à distance.</div>
                 <!-- end card-body -->
               </div>
               <!-- end collapse -->
             </div>
             <!-- end card -->
             <div class="card">
-              <div class="card-header" role="tab" id="headingFour"> <a class="collapsed" data-toggle="collapse" href="#collapseFour" aria-expanded="false" aria-controls="collapseFour"> Pourquoi choisir un contrat de maintenance RenoGo ? <i class="lni lni-arrow-right"></i></a> </div>
+              <div class="card-header" role="tab" id="headingFour"> <a class="collapsed" data-toggle="collapse" href="#collapseFour" aria-expanded="false" aria-controls="collapseFour"> Proposez-vous des contrats de maintenance ? <i class="lni lni-arrow-right"></i></a> </div>
               <div id="collapseFour" class="collapse" role="tabpanel" aria-labelledby="headingFour" data-parent="#accordion">
-                <div class="card-body"> Nos contrats préventifs et réactifs couvrent électricité, CVC, plomberie, espaces verts et services aux occupants. Vous bénéficiez d’un interlocuteur unique, de rapports réglementaires et d’un budget maîtrisé toute l’année.</div>
+                <div class="card-body"> Nous proposons des formules préventives et correctives pour les copropriétés, bureaux et établissements recevant du public. Jardins, éclairages, systèmes domotiques et contrôles réglementaires : RenoGo s'occupe de tout pour sécuriser vos installations.</div>
                 <!-- end card-body -->
               </div>
               <!-- end collapse -->
@@ -469,8 +469,8 @@
                 <div class="col-lg-4">
                 <div class="info-box-dark">
                         <h6>BOÎTE À IDÉES</h6>
-                        <p>Besoin d’un brainstorming pour repenser vos espaces ? Nous co-créons vos plans d’aménagement, du flex office à l’extension familiale, avec moodboards matériaux et simulations 3D.</p>
-                        <p>Recevez notre guide gratuit « Rénover et maintenir vos espaces en Normandie & Île-de-France » : études de cas, check-lists réglementaires et calendrier d’entretien saisonnier.</p>
+                        <p>Besoin d'inspiration pour transformer votre longère ou votre open-space ? Nos conseillers viennent sur place pour imaginer avec vous un parcours travaux optimisé et respectueux de l'identité normande.</p>
+                        <p>Demandez notre guide gratuit « Habiter la Normandie autrement » pour découvrir des réalisations à Bayeux, Cherbourg et Alençon, ainsi que nos astuces entretien selon les saisons.</p>
                         </div>
                         <!-- end info-box-dark -->
                 </div>
@@ -486,9 +486,9 @@
                         <div class="row">
                                 <div class="col-lg-8">
                                 <div class="cta-box-yellow">
-                                        <h4>Notre premier chantier, c’est votre sérénité</h4>
-                                        <p>Avant de lancer les travaux, nous cartographions vos priorités, planifions les interventions par lot et mettons en place un protocole de suivi partagé avec vos équipes. Résultat : un projet fluide, sans surprise et orienté performance.</p>
-                                        <a href="contact.html" class="button">PLANIFIER UN RENDEZ-VOUS</a>
+                                        <h4>Le premier ouvrage RenoGo, c'est la confiance</h4>
+                                        <p>Avant chaque chantier, nous prenons le temps de visiter votre lieu de vie, de comprendre vos habitudes et d'écrire un scénario travaux sur mesure. C'est ainsi que nous créons des intérieurs chaleureux et des extérieurs accueillants, du bocage ornais aux falaises de la Côte d'Albâtre.</p>
+                                        <a href="contact.html" class="button">OBTENIR UN DEVIS</a>
                                         </div>
                                         <!-- end cta-box-yellow -->
                                 </div>
@@ -505,7 +505,7 @@
       <div class="col-12">
 
           <figure class="logo"> <img src="images/logo.png" alt="Logo RenoGo"></figure>
-          <h2>Faites rayonner vos espaces en Normandie & Île-de-France</h2>
+          <h2>Vivez <b>mieux</b> et <b>plus sereinement</b> en Normandie</h2>
           <a href="contact.html" class="button">DEMANDER UNE CONSULTATION <i class="lni lni-arrow-right"></i></a>
                   <div class="sales-representive">
                         <figure>
@@ -539,7 +539,7 @@
       <!-- end col-6 -->
                 <div class="col-lg-6">
         <h6 class="widget-title">REJOIGNEZ NOTRE LETTRE</h6>
-       <p>Recevez chaque mois nos conseils rénovation de bureaux, astuces entretien maisons et alertes aides financières.</p>
+       <p>Recevez chaque mois nos conseils travaux, calendrier d'entretien et offres locales.</p>
                         <form>
                         <input type="email" placeholder="Saisissez votre e-mail">
                                 <input type="submit" value="JE M'INSCRIS">

--- a/contact.html
+++ b/contact.html
@@ -6,8 +6,8 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <!-- Primary SEO -->
-  <title>RenoGo • Contact rénovation et maintenance en Normandie & Île-de-France</title>
-  <meta name="description" content="Contactez RenoGo pour vos projets de rénovation de bureaux, habitats, maintenance multi-technique et efficacité énergétique en Normandie & Île-de-France.">
+  <title>RenoGo • Rénovation intérieure & amélioration de l’habitat en France</title>
+  <meta name="description" content="RenoGo rénove et transforme appartements et maisons : cuisines, salles de bain, isolation, électricité, peinture. Devis rapide, travaux qualitatifs, livrés à temps.">
   <link rel="canonical" href="https://www.renogo.fr/">
 
   <!-- Indexing -->
@@ -29,8 +29,8 @@
   <meta property="og:locale" content="fr_FR">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="RenoGo">
-  <meta property="og:title" content="RenoGo • Contact rénovation & maintenance">
-  <meta property="og:description" content="Prenez rendez-vous avec nos experts pour vos projets de bureaux et habitats en Normandie & Île-de-France.">
+  <meta property="og:title" content="RenoGo • Rénovation intérieure & amélioration de l’habitat">
+  <meta property="og:description" content="Cuisine, salle de bain, peinture, isolation et plus. Devis rapide, travaux maîtrisés.">
   <meta property="og:url" content="https://www.renogo.fr/">
   <meta property="og:image" content="https://www.renogo.fr/assets/og/renogo-cover.jpg">
   <meta property="og:image:width" content="1200">
@@ -39,8 +39,8 @@
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@renogo">
-  <meta name="twitter:title" content="RenoGo • Contact rénovation & maintenance">
-  <meta name="twitter:description" content="RenoGo coordonne vos chantiers et contrats de maintenance entre Paris et la Normandie.">
+  <meta name="twitter:title" content="RenoGo • Rénovation intérieure & amélioration de l’habitat">
+  <meta name="twitter:description" content="Rénovation d’appartements et maisons en France. Devis rapide, délais tenus.">
   <meta name="twitter:image" content="https://www.renogo.fr/assets/og/renogo-cover.jpg">
 
   <!-- Organization -->
@@ -75,7 +75,7 @@
     "url": "https://www.renogo.fr/",
     "logo": "https://www.renogo.fr/assets/logo/renogo-logo.svg",
     "image": "https://www.renogo.fr/assets/og/renogo-cover.jpg",
-    "description": "Contact pour rénovation de bureaux, logements, maintenance multi-technique et smart building.",
+    "description": "Rénovation intérieure d’appartements et maisons : cuisines, salles de bain, isolation, électricité, peinture.",
     "telephone": "+33-1-23-45-67-89",
     "areaServed": "FR",
     "priceRange": "€€",
@@ -144,10 +144,10 @@
 
     <div class="hide-mobile">
       <p>
-        RenoGo pilote vos projets de rénovation et de maintenance en Normandie &amp; Île-de-France :
-        <u>électricité &amp; éclairage</u>, <u>peinture &amp; sols</u>, <u>plomberie &amp; CVC</u>,
-        <u>jardinage &amp; aménagement paysager</u> et <u>domotique / smart building</u>.
-        Des chantiers propres, des délais tenus et un suivi de proximité.
+        RenoGo accompagne vos projets de rénovation et d’entretien en Normandie :
+        <u>électricité & éclairage</u>, <u>peinture & sols</u>, <u>cloisons & isolation</u>,
+        <u>jardinage & aménagement paysager</u>, ainsi que <u>domotique / maison intelligente</u>.
+        Des chantiers propres, des délais tenus, un suivi de proximité.
       </p>
 
       <figure class="gallery">
@@ -235,7 +235,7 @@
 <header class="page-header">
   <div class="container">
     <h1>Contactez</h1>
-          <h6>Parlez-nous de vos projets de rénovation, d’ergonomie ou de maintenance en Normandie & Île-de-France.</h6>
+          <h6>Vos projets prennent vie entre Paris et la Normandie, orchestrés par une équipe qui conjugue innovation, précision et amour du bâti.</h6>
           <ul>
                 <li><a href="index.html">Accueil</a></li>
                 <li>Contact</li>
@@ -251,7 +251,7 @@
         <div class="contact-box">
                         <figure><img src="images/icon-global.png" alt="Bureaux RenoGo"></figure>
           <h6>Maison RenoGo</h6>
-                <p>59, rue de Ponthieu, Bureau 326<br>75008 Paris<br>+ permanence Normandie : Rue d'Ezu, La Couture-Boussey</p>
+                <p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
 
         </div>
         <!-- end contact-box -->
@@ -261,7 +261,7 @@
         <div class="contact-box">
                         <figure><img src="images/icon-phone.png" alt="Téléphone RenoGo"></figure>
           <h6>Appelez-nous</h6>
-           <p>+33 (0)1 84 60 22 90<br>Service client, facility management & astreinte chantier 24/7</p>
+           <p>+33 (0)1 84 60 22 90<br>Service client & astreinte chantier</p>
         </div>
         <!-- end contact-box -->
       </div>
@@ -270,7 +270,7 @@
         <div class="contact-box">
                         <figure><img src="images/icon-email.png" alt="Email RenoGo"></figure>
           <h6>Écrivez-nous</h6>
-          <p><a href="mailto:ventes@renogo.fr">ventes@renogo.fr</a><br>Réponse sous 24 h ouvrées & suivi dans notre portail client</p>
+          <p><a href="mailto:ventes@renogo.fr">ventes@renogo.fr</a><br>Réponse sous 24 h ouvrées</p>
         </div>
         <!-- end contact-box -->
       </div>
@@ -287,8 +287,8 @@
       <div class="col-lg-6">
           <div class="section-title text-left">
           <h6>Notre promesse</h6>
-          <h2>Un interlocuteur unique<br>
-            pour vos sites normands & franciliens</h2>
+          <h2>Une équipe qui connaît<br>
+            chaque saison normande</h2>
         </div>
         <!-- end section-title -->
       </div>
@@ -307,12 +307,12 @@
                  <!-- end form-group -->
                         <div class="form-group">
                         <span>Projet</span>
-                                <input type="text" placeholder="Rénovation de bureaux, maison, maintenance..."></input>
+                                <input type="text" placeholder="Rénovation, entretien, jardin..."></input>
                  </div>
                  <!-- end form-group -->
                         <div class="form-group">
                         <span>Votre message</span>
-                                <textarea placeholder="Décrivez le site, vos objectifs énergie/confort et vos délais"></textarea>
+                                <textarea placeholder="Décrivez-nous votre besoin et vos délais"></textarea>
                  </div>
                  <!-- end form-group -->
                         <div class="form-group">
@@ -339,8 +339,8 @@
       <div class="col-12">
 
           <figure class="logo"> <img src="images/logo.png" alt="RenoGo"> </figure>
-          <h2>Prenons rendez-vous pour transformer vos espaces</h2>
-          <a href="https://outlook.office.com/book/RDVRenoGo@renogo.fr/?ismsaljsauthenabled" class="button" target="_blank" rel="noopener">PLANIFIER UN RENDEZ-VOUS <i class="lni lni-arrow-right"></i></a>
+          <h2>Construisons une Normandie <b>durable</b> et <b>inspirante</b></h2>
+          <a href="#" class="button">OBTENIR UN DEVIS <i class="lni lni-arrow-right"></i></a>
                   <div class="sales-representive">
                         <figure>
                                 <img src="images/author01.jpg" alt="Conseiller RenoGo">
@@ -373,7 +373,7 @@
       <!-- end col-6 -->
                 <div class="col-lg-6">
         <h6 class="widget-title">Lettre d'inspiration</h6>
-       <p>Recevez nos conseils rénovation, check-lists maintenance et alertes aides financières pour vos sites normands & franciliens.</p>
+       <p>Recevez nos conseils saisonniers pour protéger et sublimer vos espaces intérieurs et extérieurs.</p>
                         <form>
                         <input type="email" placeholder="Votre e-mail">
                                 <input type="submit" value="JE M'INSCRIS">
@@ -382,7 +382,7 @@
       <!-- end col-6 -->
                 <div class="col-12">
                         <div class="footer-bottom">
-                                <span>© 2024 RenoGo | Rénovation, Maintenance &amp; Paysage en Normandie &amp; Île-de-France</span>
+                                <span>© 2024 RenoGo | Rénovation, Maintenance & Paysage en Normandie</span>
                                 <ul>
                                 <li><a href="#">Facebook</a></li>
                                 <li><a href="#">Instagram</a></li>

--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <!-- Primary SEO -->
-  <title>RenoGo | Rénovation de bureaux et maisons en Normandie & Île-de-France</title>
-  <meta name="description" content="RenoGo conçoit des bureaux performants et des maisons confortables : rénovation globale, maintenance multitechnique, efficacité énergétique et domotique en Normandie et Île-de-France.">
+  <title>RenoGo • Rénovation intérieure & amélioration de l’habitat en France</title>
+  <meta name="description" content="RenoGo rénove et transforme appartements et maisons : cuisines, salles de bain, isolation, électricité, peinture. Devis rapide, travaux qualitatifs, livrés à temps.">
   <link rel="canonical" href="https://www.renogo.fr/">
 
   <!-- Indexing -->
@@ -29,8 +29,8 @@
   <meta property="og:locale" content="fr_FR">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="RenoGo">
-  <meta property="og:title" content="RenoGo | Rénovation de bureaux et maisons">
-  <meta property="og:description" content="Transformation de bureaux, rénovation d’appartements, maintenance et efficacité énergétique en Normandie et Île-de-France.">
+  <meta property="og:title" content="RenoGo • Rénovation intérieure & amélioration de l’habitat">
+  <meta property="og:description" content="Cuisine, salle de bain, peinture, isolation et plus. Devis rapide, travaux maîtrisés.">
   <meta property="og:url" content="https://www.renogo.fr/">
   <meta property="og:image" content="https://www.renogo.fr/assets/og/renogo-cover.jpg">
   <meta property="og:image:width" content="1200">
@@ -39,8 +39,8 @@
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@renogo">
-  <meta name="twitter:title" content="RenoGo | Rénovation de bureaux et maisons">
-  <meta name="twitter:description" content="Solutions clé en main pour entreprises et particuliers : rénovation, maintenance, efficacité énergétique.">
+  <meta name="twitter:title" content="RenoGo • Rénovation intérieure & amélioration de l’habitat">
+  <meta name="twitter:description" content="Rénovation d’appartements et maisons en France. Devis rapide, délais tenus.">
   <meta name="twitter:image" content="https://www.renogo.fr/assets/og/renogo-cover.jpg">
 
   <!-- Organization -->
@@ -75,9 +75,9 @@
     "url": "https://www.renogo.fr/",
     "logo": "https://www.renogo.fr/assets/logo/renogo-logo.svg",
     "image": "https://www.renogo.fr/assets/og/renogo-cover.jpg",
-    "description": "Rénovation de bureaux, modernisation de logements, maintenance multitechnique et efficacité énergétique en Normandie et Île-de-France.",
+    "description": "Rénovation intérieure d’appartements et maisons : cuisines, salles de bain, isolation, électricité, peinture.",
     "telephone": "+33-1-23-45-67-89",
-    "areaServed": ["Normandie", "Île-de-France"],
+    "areaServed": "FR",
     "priceRange": "€€",
     "foundingDate": "2025",
     "address": {
@@ -97,25 +97,25 @@
       "@type": "Offer",
       "itemOffered": {
         "@type": "Service",
-        "name": "Rénovation complète de bureaux"
+        "name": "Rénovation de salle de bain"
       }
     },{
       "@type": "Offer",
       "itemOffered": {
         "@type": "Service",
-        "name": "Maintenance multitechnique"
+        "name": "Rénovation de cuisine"
       }
     },{
       "@type": "Offer",
       "itemOffered": {
         "@type": "Service",
-        "name": "Rénovation résidentielle clé en main"
+        "name": "Peinture & finitions"
       }
     },{
       "@type": "Offer",
       "itemOffered": {
         "@type": "Service",
-        "name": "Efficacité énergétique & domotique"
+        "name": "Isolation & efficacité énergétique"
       }
     }]
   }
@@ -144,24 +144,26 @@
 
     <div class="hide-mobile">
       <p>
-        Depuis nos bureaux de Paris et de Normandie, RenoGo orchestre des rénovations rapides et durables pour les entreprises et les particuliers.
-        <u>Remise à niveau électrique</u>, <u>climatisation & chauffage bas carbone</u>, <u>design d’espaces de travail ergonomiques</u>,
-        <u>modernisation des maisons normandes</u> et <u>maintenance préventive</u> : nous pilotons chaque lot, un interlocuteur unique, zéro stress.
+        RenoGo accompagne vos projets de rénovation et d’entretien en Normandie :
+        <u>électricité & éclairage</u>, <u>peinture & sols</u>, <u>cloisons & isolation</u>,
+        <u>jardinage & aménagement paysager</u>, ainsi que <u>domotique / maison intelligente</u>.
+        Des chantiers propres, des délais tenus, un suivi de proximité.
       </p>
 
       <figure class="gallery">
-        <img src="images/slide02.jpg" alt="Plateau de bureaux ergonomiques rénové à Paris">
-        <img src="images/slide03.jpg" alt="Maison normande rénovée avec terrasse bois">
+        <img src="images/slide02.jpg" alt="Avant / après — séjour rénové à Rouen">
+        <img src="images/slide03.jpg" alt="Aménagement paysager et terrasse bois à Évreux">
       </figure>
 
       <h6 class="widget-title">ADRESSE</h6>
       <address class="address">
         <p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
-        <p>Cellule projets Île-de-France & Normandy Hub (Rouen, Caen, Évreux)</p>
-        <p>Hotline travaux : +33 2 32 00 00 05</p>
+        <p>Coordination des projets en Île-de-France<br>
+           Interventions en Normandie (Rouen, Caen, Évreux…)</p>
+        <p>+33 2 32 00 00 05</p>
       </address>
 
-      <h6 class="widget-title">SUIVEZ NOS CHANTIERS</h6>
+      <h6 class="widget-title">SUIVEZ-NOUS</h6>
       <ul class="social-media">
         <li><a href="#" rel="nofollow noopener">Facebook</a></li>
         <li><a href="#" rel="nofollow noopener">Pinterest</a></li>
@@ -176,11 +178,11 @@
         <ul>
           <li><a href="index.html">Accueil</a></li>
           <li class="has-children">
-          <a href="about-company.html">Notre ADN</a>
+         <a href="about-company.html">À propos</a></a>
           </li>
-          <li><a href="services.html">Solutions</a></li>
-          <li><a href="projects.html">Réalisations</a></li>
-          <li><a href="news.html">Insights</a></li>
+          <li><a href="services.html">Services</a></li>
+          <li><a href="projects.html">Projets</a></li>
+          <li><a href="news.html">Actualités</a></li>
           <li><a href="https://renogo.atlassian.net/servicedesk/customer/portal/2">Support</a></li>
           <li><a href="contact.html">Contact</a></li>
         </ul>
@@ -206,11 +208,11 @@
       <ul>
         <li><a href="index.html">Accueil</a></li>
         <li class="has-children">
-          <a href="about-company.html">Notre ADN</a>
+          <a href="about-company.html">À propos</a>
         </li>
-        <li><a href="services.html">Solutions</a></li>
-        <li><a href="projects.html">Réalisations</a></li>
-        <li><a href="news.html">Insights</a></li>
+        <li><a href="services.html">Services</a></li>
+        <li><a href="projects.html">Projets</a></li>
+        <li><a href="news.html">Actualités</a></li>
         <li><a href="https://renogo.atlassian.net/servicedesk/customer/portal/2">Support</a></li>
         <li><a href="contact.html">Contact</a></li>
       </ul>
@@ -238,9 +240,9 @@
         <!-- Slide 1 -->
         <div class="swiper-slide">
           <div class="inner">
-            <h1>Boostez vos <b>bureaux</b> en Île-de-France</h1>
-            <p>Audit flash, space planning ergonomique et travaux tous corps d’état coordonnés de nuit ou le week-end pour maintenir la productivité de vos équipes.</p>
-            <a href="contact.html">PLANIFIER UN AUDIT <i class="lni lni-arrow-right"></i></a>
+            <h2>Transformez votre <b>maison</b> en Normandie</h2>
+            <p>De la peinture aux jardins paysagers, RenoGo redonne vie à vos espaces intérieurs et extérieurs avec passion et savoir-faire.</p>
+            <a href="services.html">DÉCOUVRIR NOS SERVICES <i class="lni lni-arrow-right"></i></a>
           </div>
         </div>
         <!-- end swiper-slide -->
@@ -248,9 +250,9 @@
         <!-- Slide 2 -->
         <div class="swiper-slide">
           <div class="inner">
-            <h2>Réinventez votre <b>maison normande</b></h2>
-            <p>Isolation biosourcée, cuisines signature, salles de bain bien-être et jardins scénographiés : un accompagnement clé en main pour valoriser votre patrimoine.</p>
-            <a href="projects.html">VOIR NOS RÉNOVATIONS <i class="lni lni-arrow-right"></i></a>
+            <h2>Un habitat <b>confortable</b> & connecté</h2>
+            <p>Électricité, éclairage, domotique et isolation : nous modernisons votre logement pour plus de confort, d’efficacité énergétique et de sérénité.</p>
+            <a href="projects.html">VOIR NOS RÉALISATIONS <i class="lni lni-arrow-right"></i></a>
           </div>
         </div>
         <!-- end swiper-slide -->
@@ -258,9 +260,9 @@
         <!-- Slide 3 -->
         <div class="swiper-slide">
           <div class="inner">
-            <h2>Garantissez un <b>patrimoine durable</b></h2>
-            <p>Contrats de maintenance préventive, GTB, suivi énergétique et interventions express pour sécuriser vos sites tertiaires et résidentiels.</p>
-            <a href="services.html#maintenance">ACTIVER LA MAINTENANCE <i class="lni lni-arrow-right"></i></a>
+            <h2>Un cadre de vie <b>harmonieux</b></h2>
+            <p>Jardins soignés, sols élégants, murs impeccables : RenoGo crée des espaces où il fait bon vivre en Normandie.</p>
+            <a href="contact.html">DEMANDER UN DEVIS <i class="lni lni-arrow-right"></i></a>
           </div>
         </div>
         <!-- end swiper-slide -->
@@ -293,71 +295,63 @@
   <div class="container">
     <div class="row">
 
-      <div class="col-12">
-        <div class="section-title">
-          <h6>SOLUTIONS 360°</h6>
-          <h2>Un contractant général agile pour vos projets</h2>
-          <p>RenoGo rassemble architectes d’intérieur, ingénieurs et artisans certifiés pour délivrer des rénovations rapides, sécurisées et éco-responsables en Normandie et Île-de-France.</p>
+      <!-- Jardin & Paysage -->
+      <div class="col-lg-4 col-md-6">
+        <div class="icon-content">
+          <figure><img src="images/icon01.png" alt="Paysagiste et jardinier RenoGo en Normandie"></figure>
+          <h3>Jardin & Paysage</h3>
+          <small>Massifs fleuris, terrasses bois et entretien quatre saisons : nous sculptons des jardins normands généreux qui mettent en scène votre maison.</small>
+          <a href="services.html#tab01">+</a>
         </div>
       </div>
 
-      <!-- Bureaux -->
+      <!-- Electricite -->
       <div class="col-lg-4 col-md-6">
         <div class="icon-content">
-          <figure><img src="images/icon01.png" alt="Chef de projet RenoGo planifiant une rénovation de bureaux"></figure>
-          <h3>Rénovation de bureaux</h3>
-          <small>Space planning, rafraîchissement express, reprises CVC et éclairage intelligent pour des espaces de travail stimulants et conformes aux normes.</small>
-          <a href="services.html#bureaux">+</a>
+          <figure><img src="images/icon02.png" alt="Électricien certifié en mise aux normes à Rouen et Caen"></figure>
+          <h3>Électricité</h3>
+          <small>Tableaux neufs, éclairages LED et sécurité renforcée : nos électriciens certifiés sécurisent vos chantiers du littoral au pays d’Auge.</small>
+          <a href="services.html#tab02">+</a>
         </div>
       </div>
 
-      <!-- Maintenance -->
+      <!-- Maison Connecte -->
       <div class="col-lg-4 col-md-6">
         <div class="icon-content">
-          <figure><img src="images/icon02.png" alt="Technicien RenoGo assurant une maintenance multitechnique"></figure>
-          <h3>Maintenance multitechnique</h3>
-          <small>Contrats préventifs et interventions d’urgence 24/7 pour vos installations électriques, plomberie, climatisation et sûreté.</small>
-          <a href="services.html#maintenance">+</a>
+          <figure><img src="images/icon06.png" alt="Solutions de maison connectée et domotique en Normandie"></figure>
+          <h3>Maison Connectée</h3>
+          <small>Pilotage à distance, Wi-Fi, scénarios lumière et chauffage intelligent : RenoGo transforme votre demeure normande en maison connectée intuitive.</small>
+          <a href="services.html#services-electricite">+</a>
+        </div>
+      </div></br></br>
+
+      <!-- Peinture -->
+      <div class="col-lg-4 col-md-6">
+        <div class="icon-content">
+          <figure><img src="images/icon03.png" alt="Peintres RenoGo réalisant des finitions haut de gamme"></figure>
+          <h3>Peinture</h3>
+          <small>Finitions veloutées, teintes minérales inspirées des falaises d’Étretat et protections durables pour sublimer murs et boiseries.</small>
+          <a href="services.html#tab03">+</a>
         </div>
       </div>
 
-      <!-- Smart Office -->
+      <!-- Mur & Sol -->
       <div class="col-lg-4 col-md-6">
         <div class="icon-content">
-          <figure><img src="images/icon06.png" alt="Solutions smart office et domotique par RenoGo"></figure>
-          <h3>Smart office & domotique</h3>
-          <small>Salles de réunion connectées, GTB, sécurité et monitoring énergétique pour piloter vos bâtiments à distance.</small>
-          <a href="services.html#smart">+</a>
-        </div>
-      </div><br><br>
-
-      <!-- Résidentiel -->
-      <div class="col-lg-4 col-md-6">
-        <div class="icon-content">
-          <figure><img src="images/icon03.png" alt="Architecte d’intérieur RenoGo rénovant une maison normande"></figure>
-          <h3>Rénovation résidentielle</h3>
-          <small>Design intérieur, salles de bain spa, cuisines conviviales et extensions lumineuses pour maisons et appartements de caractère.</small>
-          <a href="services.html#maisons">+</a>
+          <figure><img src="images/icon05.png" alt="Pose de cloisons sèches et revêtements de sol RenoGo"></figure>
+          <h3>Mur & Sol</h3>
+          <small>Cloisons légères, parquet chêne de Normandie ou carrelage grand format : nous structurons et habillons vos volumes avec élégance.</small>
+          <a href="services.html#tab05">+</a>
         </div>
       </div>
 
-      <!-- Performance énergétique -->
+      <!-- Isolation -->
       <div class="col-lg-4 col-md-6">
         <div class="icon-content">
-          <figure><img src="images/icon05.png" alt="Isolation et solutions énergétiques RenoGo"></figure>
-          <h3>Performance énergétique</h3>
-          <small>Isolation biosourcée, HVAC haut rendement, éclairage LED et pilotage des consommations pour réduire vos charges.</small>
-          <a href="services.html#energie">+</a>
-        </div>
-      </div>
-
-      <!-- Extérieurs -->
-      <div class="col-lg-4 col-md-6">
-        <div class="icon-content">
-          <figure><img src="images/icon04.png" alt="Aménagement paysager RenoGo pour bureaux et maisons"></figure>
-          <h3>Paysages & extérieurs</h3>
-          <small>Jardins, terrasses, patios collaboratifs et entretien quatre saisons pour magnifier vos espaces de vie et d’accueil.</small>
-          <a href="services.html#outdoor">+</a>
+          <figure><img src="images/icon04.png" alt="Isolation thermique et acoustique pour maisons normandes"></figure>
+          <h3>Isolation</h3>
+          <small>Laine de bois, ouate et solutions biosourcées : optimisez votre confort thermique et acoustique tout en valorisant votre bâti.</small>
+          <a href="services.html#tab04">+</a>
         </div>
       </div>
 
@@ -370,9 +364,9 @@
     <div class="row align-items-center">
       <div class="col-12">
         <div class="section-title">
-          <h6>NOTRE SIGNATURE</h6>
-          <h2>La rénovation qui accélère<br>
-            vos projets immobiliers</h2>
+          <h6>NOTRE HISTOIRE</h6>
+          <h2>Qualité & Passion<br>
+            au service de votre habitat</h2>
         </div>
         <!-- end section-title --> 
       </div>
@@ -380,21 +374,21 @@
 
       <div class="col-lg-6">
         <figure class="side-image">
-          <img src="images/side-image012.png" alt="Équipe RenoGo coordonnant un chantier tertiaire et résidentiel">
+          <img src="images/side-image012.png" alt="Travaux de rénovation maison Normandie">
         </figure>
       </div>
       <!-- end col-6 -->
 
       <div class="col-lg-6">
         <div class="side-content">
-          <h5>RenoGo, né sur les chantiers normands et propulsé par l’exigence parisienne</h5>
-          <p>Nous avons commencé par rénover les maisons en pierre de Caen avant d’accompagner les sièges sociaux franciliens. Aujourd’hui, RenoGo est votre <b>chef d’orchestre tous corps d’état</b> pour transformer bureaux, coworkings, appartements et résidences secondaires.</p>
+          <h5>Une entreprise née de la confiance des familles normandes</h5>
+          <p>Active dans toute la Normandie, RenoGo accompagne les particuliers et entreprises dans leurs projets de rénovation, d’aménagement intérieur et d’entretien. Notre objectif : créer des espaces de vie plus confortables, esthétiques et durables.</p>
 
-          <p>Nos chefs de projet pilotent <b>électricité, CVC, plomberie, second œuvre et paysagisme</b> avec une même obsession : livrer vite, bien et en toute transparence. Éco-matériaux, domotique, accessibilité et ergonomie sont intégrés dès la conception pour maximiser la valeur de votre actif.</p>
+          <p>De l’<b>isolation thermique</b> à la <b>peinture décorative</b>, en passant par l’<b>installation électrique et la domotique</b>, nos équipes pluridisciplinaires travaillent avec rigueur et passion. Chaque projet est unique, et nous mettons un point d’honneur à respecter vos délais, votre budget et vos attentes.</p>
 
           <figure><img src="images/minilogo.png" alt="Logo RenoGo"></figure>
           <h6>L’équipe RenoGo</h6>
-          <small>Partenaire rénovation & maintenance en Normandie et Île-de-France</small>
+          <small>Votre partenaire rénovation & entretien en Normandie</small>
         </div>
       </div>
       <!-- end col-6 --> 
@@ -410,18 +404,18 @@
       <!-- Counter 1 -->
       <div class="col-lg-3 col-md-6">
         <div class="counter-box"> 
-          <span class="odometer" data-count="94" data-status="yes">0</span> <span class="value">%</span>
-          <h6>Chantiers livrés en site occupé</h6>
-          <p>Planification agile, travaux en horaires décalés et coordination HSE pour ne pas perturber vos équipes.</p>
+          <span class="odometer" data-count="98" data-status="yes">0</span> <span class="value">%</span>
+          <h6>Clients satisfaits</h6>
+          <p>Un taux de satisfaction élevé grâce à notre écoute et notre accompagnement personnalisé.</p>
         </div>
       </div>
 
       <!-- Counter 2 -->
       <div class="col-lg-3 col-md-6">
         <div class="counter-box"> 
-          <span class="odometer" data-count="68" data-status="yes">0</span> <span class="value">+</span>
-          <h6>Contrats de maintenance actifs</h6>
-          <p>Bureaux, cliniques, commerces : nos techniciens suivent vos installations et interviennent avant la panne.</p>
+          <span class="odometer" data-count="15" data-status="yes">0</span> <span class="value">+</span>
+          <h6>Années d’expertise cumulée</h6>
+          <p>Notre équipe réunit plus de 15 ans d’expérience dans des projets menés dans divers secteurs.</p>
         </div>
       </div>
 
@@ -429,18 +423,18 @@
       <!-- Counter 3 -->
       <div class="col-lg-3 col-md-6">
         <div class="counter-box"> 
-          <span class="odometer" data-count="320" data-status="yes">0</span> <span class="value">+</span>
-          <h6>Logements modernisés</h6>
-            <p>Des rénovations basse consommation, connectées et élégantes pour maisons, appartements et résidences secondaires.</p>
+          <span class="odometer" data-count="350" data-status="yes">0</span> <span class="value">+</span>
+          <h6>Clients accompagnés</h6>
+            <p>Un engagement total pour la qualité, l’écoute et le suivi personnalisé de chaque client.</p>
         </div>
       </div>
 
       <!-- Counter 4 -->
       <div class="col-lg-3 col-md-6">
         <div class="counter-box"> 
-          <span class="odometer" data-count="120" data-status="yes">0</span> <span class="value">min</span>
-          <h6>Délai moyen d’intervention</h6>
-          <p>Un centre de pilotage basé à Paris et Rouen pour déclencher vos interventions critiques en moins de 2&nbsp;heures.</p>
+          <span class="odometer" data-count="24" data-status="yes">0</span> <span class="value">/7</span>
+          <h6>Support réactif</h6>
+          <p>Une équipe disponible pour répondre à vos besoins et assurer le suivi de vos projets.</p>
         </div>
       </div>
 
@@ -453,13 +447,13 @@
     <div class="row">
       <div class="col-lg-7">
         <div class="section-title text-left">
-          <h6>PROJETS RÉFÉRENCE</h6>
-          <h2>Bureaux inspirants & habitats rénovés<br>
-            entre Normandie et Île-de-France</h2>
+          <h6>PROJETS RÉALISÉS</h6>
+          <h2>Des rénovations réussies<br>
+            en Normandie et Île-de-France</h2>
         </div>
       </div>
       <div class="col-lg-5">
-        <p>Nous adaptons nos équipes au rythme de vos chantiers : flex-office livré en quatre semaines à La Défense, appartement haussmannien sublimé à Caen, villa normande transformée en gîte premium à Honfleur. Objectif : <b>créer des espaces performants, durables et désirables</b> pour vos collaborateurs comme pour votre famille.</p>
+        <p>Chaque projet RenoGo est une histoire unique : de la modernisation d’un appartement ancien à Caen, à l’aménagement d’un jardin paysager à Rouen, en passant par la rénovation complète d’une maison familiale à Évreux. Notre passion : transformer vos idées en espaces de vie confortables, durables et élégants.</p>
       </div>
     </div>
   </div>
@@ -471,11 +465,11 @@
       <div class="swiper-slide">
         <figure class="project-box">
           <a href="projects.html#maison-rouen">
-            <img src="images/slide011.jpg" alt="Plateau tertiaire rénové par RenoGo à Paris">
+            <img src="images/slide011.jpg" alt="Rénovation maison familiale à Rouen">
           </a>
           <figcaption>
-            <h5>Plateau tertiaire Paris 8</h5>
-            <p>Plateau de 450&nbsp;m² repensé en flex-office : cloisonnement mobile, éclairage circadien et mobilier ergonomique.</p>
+            <h5>Maison familiale à Rouen</h5>
+            <p>Isolation thermique, peinture et pose de parquet pour améliorer confort et efficacité énergétique.</p>
           </figcaption>
         </figure>
       </div>
@@ -484,11 +478,11 @@
       <div class="swiper-slide">
         <figure class="project-box">
           <a href="projects.html#appartement-caen">
-            <img src="images/slide012.jpg" alt="Appartement rénové par RenoGo à Caen">
+            <img src="images/slide012.jpg" alt="Rénovation appartement ancien à Caen">
           </a>
           <figcaption>
-            <h5>Appartement historique à Caen</h5>
-            <p>Modernisation énergétique, cuisine signature et pilotage domotique pour un confort haut de gamme.</p>
+            <h5>Appartement ancien à Caen</h5>
+            <p>Rénovation électrique complète, installation d’un éclairage moderne et intégration domotique.</p>
           </figcaption>
         </figure>
       </div>
@@ -497,11 +491,11 @@
       <div class="swiper-slide">
         <figure class="project-box">
           <a href="projects.html#jardin-evreux">
-            <img src="images/slide013.jpg" alt="Aménagement paysager RenoGo à Évreux">
+            <img src="images/slide013.jpg" alt="Aménagement paysager à Évreux">
           </a>
           <figcaption>
-            <h5>Campus vert à Évreux</h5>
-            <p>Patio collaboratif, potager partagé et éclairage solaire pour une expérience bien-être indoor/outdoor.</p>
+            <h5>Jardin à Évreux</h5>
+            <p>Création d’un espace vert harmonieux avec pelouse, terrasse bois et massifs fleuris.</p>
           </figcaption>
         </figure>
       </div>
@@ -518,44 +512,44 @@
     <div class="row no-gutters">
       <div class="col-12">
         <div class="section-title text-left">
-          <h6>SECTEURS SERVIS</h6>
-          <h2>Des solutions ciblées pour<br> chaque typologie d’espace</h2>
+          <h6>DOMAINES D’INTERVENTION</h6>
+          <h2>Nos expertises pour<br> votre maison et vos locaux</h2>
         </div>
       </div>
 
       <div class="col-lg-4 col-md-6">
         <a href="services.html#maisons" class="sector-box">
-          <span>Maisons individuelles & villas</span> <i class="lni lni-arrow-right"></i>
+          <span>Maisons individuelles</span> <i class="lni lni-arrow-right"></i>
         </a>
       </div>
 
       <div class="col-lg-4 col-md-6">
         <a href="services.html#appartements" class="sector-box">
-          <span>Appartements & biens locatifs</span> <i class="lni lni-arrow-right"></i>
+          <span>Appartements</span> <i class="lni lni-arrow-right"></i>
         </a>
       </div>
 
       <div class="col-lg-4 col-md-6">
         <a href="services.html#bureaux" class="sector-box">
-          <span>Bureaux & coworkings</span> <i class="lni lni-arrow-right"></i>
+          <span>Bureaux & open spaces</span> <i class="lni lni-arrow-right"></i>
         </a>
       </div>
 
       <div class="col-lg-4 col-md-6">
         <a href="services.html#commerces" class="sector-box">
-          <span>Commerces & cabinets médicaux</span> <i class="lni lni-arrow-right"></i>
+          <span>Commerces & locaux</span> <i class="lni lni-arrow-right"></i>
         </a>
       </div>
 
       <div class="col-lg-4 col-md-6">
         <a href="services.html#jardins" class="sector-box">
-          <span>Jardins & terrasses d’entreprise</span> <i class="lni lni-arrow-right"></i>
+          <span>Jardins & espaces verts</span> <i class="lni lni-arrow-right"></i>
         </a>
       </div>
 
       <div class="col-lg-4 col-md-6">
         <a href="services.html#coproprietes" class="sector-box">
-          <span>Copropriétés & résidences services</span> <i class="lni lni-arrow-right"></i>
+          <span>Copropriétés & résidences</span> <i class="lni lni-arrow-right"></i>
         </a>
       </div>
 
@@ -570,8 +564,8 @@
     <div class="row no-gutters">
       <div class="col-12">
         <div class="section-title text-left">
-          <h6>ESTIMATION EXPRESS</h6>
-          <h2>Calculez votre budget travaux<br> en moins d’une minute</h2>
+          <h6>ESTIMATION INSTANTANÉE</h6>
+          <h2>Calculateur de budget rénovation</h2>
         </div>
         <!-- end section-title --> 
       </div>
@@ -630,7 +624,7 @@
             
             <!-- Yes/No -->
             <div class="form-group col-lg-4 col-md-12">
-              <p>Espace extérieur (terrasse/jardin / rooftop) :</p>
+              <p>Espace extérieur (terrasse/jardin) :</p>
               <div class="yes-no" id="yes-no">
                 <input type="radio" name="rdo" id="yes" value="1200" checked />
                 <input type="radio" name="rdo" id="no" value="0" />
@@ -646,7 +640,7 @@
 
             <!-- Checkboxes -->
             <div class="form-group col-12" id="checkboxes">
-              <p>Lots techniques & prestations (cochez ce qui s’applique)</p>
+              <p>Matériaux & prestations (cochez ce qui s’applique)</p>
 
               <input type="checkbox" id="one" value="25" checked>
               <label class="custom-checkbox" for="one"> Peinture murs & plafonds </label>
@@ -668,7 +662,7 @@
             <div class="form-group col-12">
               <div class="info-box">
                 <i class="lni lni-checkmark-circle"></i>
-                Estimation indicative basée sur vos choix. Pour un devis précis en Normandie ou Île-de-France, <a href="contact.html">contactez RenoGo</a>.
+                Estimation indicative basée sur vos choix. Pour un devis précis en Normandie, <a href="contact.html">contactez RenoGo</a>.
               </div>
 
               <div class="price-box">
@@ -696,9 +690,9 @@
     <div class="row">
       <div class="col-12">
         <div class="section-title">
-          <h6>MÉTHODE RENOGO</h6>
-          <h2>Un pilotage travaux sans rupture d’activité</h2>
-          <p class="mt-2">Nous combinons expertise chantier, technologie et communication proactive pour sécuriser chaque étape.</p>
+          <h6>NOTRE PROCESSUS</h6>
+          <h2>Comment se déroule votre projet</h2>
+          <p class="mt-2">Un accompagnement simple et transparent, de la première visite à la garantie après travaux.</p>
         </div>
       </div>
     </div>
@@ -708,8 +702,8 @@
       <div class="col">
         <div class="sales-team">
           <div class="infos">
-            <h6>1. Audit & diagnostic</h6>
-            <small>Visite sur site, relevés 3D, analyse énergétique et audit HSE pour cadrer le projet.</small>
+            <h6>1. Visite & Étude</h6>
+            <small>Analyse de vos besoins sur site ou à distance.</small>
           </div>
         </div>
       </div>
@@ -717,8 +711,8 @@
       <div class="col">
         <div class="sales-team">
           <div class="infos">
-            <h6>2. Design & budget</h6>
-            <small>Plans d’implantation, moodboards matériaux et chiffrage optimisé par lot.</small>
+            <h6>2. Devis final</h6>
+            <small>Proposition détaillée avec budget et planning précis.</small>
           </div>
         </div>
       </div>
@@ -726,8 +720,8 @@
       <div class="col">
         <div class="sales-team">
           <div class="infos">
-            <h6>3. Planning agile</h6>
-            <small>Phasage en site occupé, coordination des équipes et rétroplanning partagé.</small>
+            <h6>3. Contrat</h6>
+            <small>Validation des engagements et planification du chantier.</small>
           </div>
         </div>
       </div>
@@ -735,8 +729,8 @@
       <div class="col">
         <div class="sales-team">
           <div class="infos">
-            <h6>4. Travaux & suivi digital</h6>
-            <small>Points hebdo, reporting photo et contrôle qualité en temps réel via notre plateforme.</small>
+            <h6>4. Travaux</h6>
+            <small>Exécution soignée et suivi qualité permanent.</small>
           </div>
         </div>
       </div>
@@ -744,8 +738,8 @@
       <div class="col">
         <div class="sales-team">
           <div class="infos">
-            <h6>5. Livraison & maintenance</h6>
-            <small>Réception accompagnée, levée de réserves puis contrat de maintenance préventive.</small>
+            <h6>5. Garantie & Support</h6>
+            <small>Assistance après travaux et garantie des réalisations.</small>
           </div>
         </div>
       </div>
@@ -771,40 +765,40 @@
 
             <div class="swiper-slide">
               <div class="testimonial">
-                <p>“Plateau livré en 5 week-ends, zéro incident IT. Nos équipes n’ont jamais quitté le bureau, et le résultat est ultra moderne.”</p>
+                <p>“RenoGo a rénové notre séjour et refait toute l’électricité. Chantier propre, délais tenus et conseils au top. On recommande !”</p>
                 <i class="lni lni-quotation"></i>
-                <h6>Caroline, Office Manager</h6>
-                <small>Scale-up tech – Paris</small>
+                <h6>William J.</h6>
+                <small>Rouen (76)</small>
               </div>
             </div>
             <!-- end swiper-slide -->
 
             <div class="swiper-slide">
               <div class="testimonial">
-                <p>“Ils ont traité l’isolation, la PAC et la domotique en un seul contrat. Nos dépenses d’énergie ont chuté de 32&nbsp;%.”</p>
+                <p>“Isolation et peinture impeccables. On sent une vraie équipe, à l’écoute et réactive. Excellent rapport qualité-prix.”</p>
                 <i class="lni lni-quotation"></i>
-                <h6>Sébastien & Amélie</h6>
-                <small>Propriétaires – Deauville</small>
+                <h6>Sarah L.</h6>
+                <small>Caen (14)</small>
               </div>
             </div>
             <!-- end swiper-slide -->
 
             <div class="swiper-slide">
               <div class="testimonial">
-                <p>“Le patio végétalisé et les espaces détente extérieurs boostent le bien-être des équipes, même en hiver.”</p>
+                <p>“Aménagement paysager réalisé avec soin, terrasse bois superbe. Le jardin est devenu notre pièce préférée.”</p>
                 <i class="lni lni-quotation"></i>
-                <h6>Hugues, DRH</h6>
-                <small>Centre de soins – Rouen</small>
+                <h6>Martin & Claire</h6>
+                <small>Évreux (27)</small>
               </div>
             </div>
             <!-- end swiper-slide -->
 
             <div class="swiper-slide">
               <div class="testimonial">
-                <p>“Chantier coordonné à distance via leur appli. Nous avons emménagé dans une maison prête à vivre, connectée et sécurisée.”</p>
+                <p>“Pose de sol PVC et éclairage LED : résultat moderne et chaleureux. RenoGo a géré de A à Z, sans stress.”</p>
                 <i class="lni lni-quotation"></i>
-                <h6>Élodie P.</h6>
-                <small>Retraitée – Caen</small>
+                <h6>Nicolas P.</h6>
+                <small>Le Havre (76)</small>
               </div>
             </div>
             <!-- end swiper-slide -->
@@ -834,8 +828,8 @@
     <div class="row">
       <div class="col-12">
         <div class="section-title">
-          <h6>GUIDES & ACTUALITÉS</h6>
-          <h2>Inspiration pour vos projets de rénovation responsables</h2>
+          <h6>ACTUALITÉS & CONSEILS</h6>
+          <h2>Dernières nouvelles de RenoGo</h2>
         </div>
         <!-- end section-title --> 
       </div>
@@ -843,11 +837,11 @@
       <div class="col-lg-5">
         <div class="recent-news">
           <figure>
-            <img src="images/slide01.jpg" alt="Transformation d’un plateau tertiaire par RenoGo">
+            <img src="images/slide01.jpg" alt="Avant / après : rénovation complète d’un séjour à Rouen">
           </figure>
           <div class="content">
             <small>12 septembre 2025</small>
-            <h3><a href="news/renovation-sejour-rouen.html">Comment réussir une rénovation de bureaux en site occupé sans bloquer vos équipes</a></h3>
+            <h3><a href="news/renovation-sejour-rouen.html">Avant/Après : peinture, sols et éclairage LED pour un séjour lumineux à Rouen</a></h3>
             <div class="author">
               <img src="images/author01.jpg" alt="Équipe RenoGo">
               <span>par <b>Équipe RenoGo</b></span>
@@ -869,7 +863,7 @@
               </figure>
               <div class="content">
                 <small>05 septembre 2025</small>
-                <h3><a href="news/isolation-thermique-normandie.html">Isolation en Normandie : quelles solutions biosourcées pour réduire vos charges ?</a></h3>
+                <h3><a href="news/isolation-thermique-normandie.html">Isolation en Normandie : comment gagner en confort et baisser votre facture</a></h3>
                 <div class="author">
                   <img src="images/author01.jpg" alt="Équipe RenoGo">
                   <span>par <b>Équipe RenoGo</b></span>
@@ -887,7 +881,7 @@
               </figure>
               <div class="content">
                 <small>28 août 2025</small>
-                <h3><a href="news/domotique-eclairage-securite.html">Domotique & smart office : 5 scénarios qui boostent la performance énergétique</a></h3>
+                <h3><a href="news/domotique-eclairage-securite.html">Domotique : éclairage intelligent & sécurité — nos conseils pour démarrer</a></h3>
                 <div class="author">
                   <img src="images/author01.jpg" alt="Équipe RenoGo">
                   <span>par <b>Équipe RenoGo</b></span>
@@ -914,11 +908,11 @@
     <div class="row">
       <div class="col-12">
         <figure class="logo"><img src="images/logo.png" alt="Logo RenoGo"></figure>
-        <h2>Créez des espaces <b>performants</b> et <b>inspirants</b></h2>
-        <a href="contact.html" class="button">DÉMARRER MON PROJET <i class="lni lni-arrow-right"></i></a>
+        <h2>Vivez <b>mieux</b> et <b>plus beau</b></h2>
+        <a href="contact.html" class="button">DEMANDER UN DEVIS <i class="lni lni-arrow-right"></i></a>
         <div class="sales-representive">
           <figure><img src="images/author01.jpg" alt="Conseiller RenoGo"></figure>
-          Cellule projets RenoGo <b>+33 2 32 00 00 05</b> — appel gratuit
+          Conseiller RenoGo <b>+33 2 32 00 00 05</b> — appel gratuit
         </div>
         <!-- end sales-representive -->
       </div>
@@ -935,18 +929,18 @@
     <div class="row">
 
       <div class="col-lg-6 col-md-6">
-        <h6 class="widget-title">Bureaux & zones d’intervention</h6>
+        <h6 class="widget-title">Bureau principal</h6>
         <address>
-          <p>Siège Île-de-France : 59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
-          <p>Hub Normandie : Rue d'Ezu, La Couture-Boussey</p>
-          <p>Standard : +33 (0)1 84 60 22 90</p>
+          <p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
+          <p>Permanence Normandie: Rue d'Ezu, La Couture-Boussey</p>
+          <p>+33 (0)1 84 60 22 90</p>
           <a href="https://www.google.com/maps/search/?api=1&query=59+rue+de+Ponthieu+Bureau+326+75008+Paris" data-fancybox data-width="640" data-height="360">Nous trouver</a>
         </address>
       </div>
       <!-- end col-6 -->
       <div class="col-lg-6">
         <h6 class="widget-title">Lettre d'inspiration</h6>
-        <p>Chaque mois : retours d’expérience chantier, check-lists maintenance et tendances design pour vos espaces.</p>
+        <p>Recevez nos conseils saisonniers pour protéger et sublimer vos espaces intérieurs et extérieurs.</p>
         <form>
           <input type="email" placeholder="Votre e-mail">
           <input type="submit" value="JE M'INSCRIS">
@@ -955,7 +949,7 @@
       <!-- end col-6 -->
       <div class="col-12">
         <div class="footer-bottom">
-          <span>© 2025 RenoGo • Rénovation & maintenance durables — Normandie & Île-de-France</span>
+          <span>© 2025 RenoGo • Rénovation intérieure & extérieure — Normandie</span>
           <ul>
             <li><a href="https://www.facebook.com/" rel="nofollow noopener">Facebook</a></li>
             <li><a href="https://www.instagram.com/" rel="nofollow noopener">Instagram</a></li>

--- a/news.html
+++ b/news.html
@@ -6,8 +6,8 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <!-- Primary SEO -->
-  <title>RenoGo • Actualités rénovation, maintenance et énergie en Normandie & Île-de-France</title>
-  <meta name="description" content="Suivez l’actualité RenoGo : chantiers de bureaux, rénovations de maisons, innovations smart building et conseils maintenance pour les territoires Normandie & Île-de-France.">
+  <title>RenoGo • Rénovation intérieure & amélioration de l’habitat en France</title>
+  <meta name="description" content="RenoGo rénove et transforme appartements et maisons : cuisines, salles de bain, isolation, électricité, peinture. Devis rapide, travaux qualitatifs, livrés à temps.">
   <link rel="canonical" href="https://www.renogo.fr/">
 
   <!-- Indexing -->
@@ -29,8 +29,8 @@
   <meta property="og:locale" content="fr_FR">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="RenoGo">
-  <meta property="og:title" content="RenoGo • Actualités rénovation & maintenance">
-  <meta property="og:description" content="Insights chantiers, énergie et smart building pour entreprises et particuliers en Normandie & Île-de-France.">
+  <meta property="og:title" content="RenoGo • Rénovation intérieure & amélioration de l’habitat">
+  <meta property="og:description" content="Cuisine, salle de bain, peinture, isolation et plus. Devis rapide, travaux maîtrisés.">
   <meta property="og:url" content="https://www.renogo.fr/">
   <meta property="og:image" content="https://www.renogo.fr/assets/og/renogo-cover.jpg">
   <meta property="og:image:width" content="1200">
@@ -39,8 +39,8 @@
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@renogo">
-  <meta name="twitter:title" content="RenoGo • Actualités rénovation & maintenance">
-  <meta name="twitter:description" content="Découvrez les tendances énergie, design et facility management suivies par RenoGo entre Paris et la Normandie.">
+  <meta name="twitter:title" content="RenoGo • Rénovation intérieure & amélioration de l’habitat">
+  <meta name="twitter:description" content="Rénovation d’appartements et maisons en France. Devis rapide, délais tenus.">
   <meta name="twitter:image" content="https://www.renogo.fr/assets/og/renogo-cover.jpg">
 
   <!-- Organization -->
@@ -75,7 +75,7 @@
     "url": "https://www.renogo.fr/",
     "logo": "https://www.renogo.fr/assets/logo/renogo-logo.svg",
     "image": "https://www.renogo.fr/assets/og/renogo-cover.jpg",
-    "description": "Actualités rénovation de bureaux et maisons, maintenance multi-technique et smart building.",
+    "description": "Rénovation intérieure d’appartements et maisons : cuisines, salles de bain, isolation, électricité, peinture.",
     "telephone": "+33-1-23-45-67-89",
     "areaServed": "FR",
     "priceRange": "€€",
@@ -144,10 +144,10 @@
 
     <div class="hide-mobile">
       <p>
-        RenoGo pilote vos projets de rénovation et de maintenance en Normandie &amp; Île-de-France :
-        <u>électricité &amp; éclairage</u>, <u>peinture &amp; sols</u>, <u>plomberie &amp; CVC</u>,
-        <u>jardinage &amp; aménagement paysager</u> et <u>domotique / smart building</u>.
-        Des chantiers propres, des délais tenus et un suivi de proximité.
+        RenoGo accompagne vos projets de rénovation et d’entretien en Normandie :
+        <u>électricité & éclairage</u>, <u>peinture & sols</u>, <u>cloisons & isolation</u>,
+        <u>jardinage & aménagement paysager</u>, ainsi que <u>domotique / maison intelligente</u>.
+        Des chantiers propres, des délais tenus, un suivi de proximité.
       </p>
 
       <figure class="gallery">
@@ -233,7 +233,7 @@
 <header class="page-header">
   <div class="container">
     <h1>Actualités</h1>
-          <h6>Insights chantiers, énergie et innovations RenoGo pour la Normandie & l’Île-de-France.</h6>
+          <h6>Histoires vraies de jardins métamorphosés, d'intérieurs réinventés et de maintenance préventive dans toute la Normandie.</h6>
           <ul>
                 <li><a href="index.html">Accueil</a></li>
                 <li>Actualités</li>
@@ -251,8 +251,8 @@
                         <img src="images/slide01.jpg" alt="Jardin durable à Caen">
                            </figure>
           <div class="content"> <small>12 mars 2024</small>
-            <h3><a href="news-single.html">Caen : un jardin de pluie pour un immeuble tertiaire &amp; résidentiel</a></h3>
-            <p>Quartier Venoix, nous avons remplacé 180 m² de béton par un jardin de pluie qui capte 12&nbsp;m³ d’eau de ruissellement. Résultat : biodiversité renforcée, réduction des risques d’inondation et espaces détente pour les salariés comme les habitants.</p>
+            <h3><a href="news-single.html">Un jardin de pluie à Caen : RenoGo sublime la biodiversité urbaine</a></h3>
+            <p>Dans le quartier Venoix, nous avons transformé une cour bétonnée en oasis végétale qui récupère l'eau normande et protège la maison des inondations. L'aménagement paysager et l'arrosage intelligent dialoguent désormais pour un jardin autonome.</p>
             <div class="author"> <img src="images/author01.jpg" alt="Consultante RenoGo"> <span>par <b>Camille, paysagiste RenoGo</b></span> </div>
             <!-- end author -->
                          </div>
@@ -265,8 +265,8 @@
                         <img src="images/slide02.jpg" alt="Équipe électriciens Rouen">
                            </figure>
           <div class="content"> <small>4 mars 2024</small>
-            <h3><a href="news-single.html">Rouen : éclairage intelligent pour un cabinet d’avocats</a></h3>
-            <p>Relamping LED, capteurs de luminosité et scénarios domotiques permettent désormais à ce cabinet de réduire sa consommation de 32&nbsp;% tout en améliorant le confort visuel des équipes et la conformité réglementaire.</p>
+            <h3><a href="news-single.html">Rouen : la lumière naturelle prolongée grâce à une domotique maline</a></h3>
+            <p>Pour un cabinet d'avocats rue Jeanne-d'Arc, nos experts en électricité ont installé un pilotage lumineux qui optimise chaque rayon normand. Résultat : 32 % d'économie d'énergie et une ambiance de travail apaisée.</p>
             <div class="author"> <img src="images/author02.jpg" alt="Chef de projet RenoGo"> <span>par <b>Louis, chef de projet électricité</b></span> </div>
             <!-- end author -->
                          </div>
@@ -279,8 +279,8 @@
                         <img src="images/slide03.jpg" alt="Appartement rénové à Deauville">
                            </figure>
           <div class="content"> <small>27 février 2024</small>
-            <h3><a href="news-single.html">Deauville : résidence secondaire connectée et inspirée</a></h3>
-            <p>Palette inspirée des Planches, peintures biosourcées, enduits protecteurs et pilotage smart home : cet appartement secondaire offre désormais un confort hôtelier avec suivi énergétique à distance.</p>
+            <h3><a href="news-single.html">Deauville : peinture satinée et atmosphère balnéaire pour une résidence secondaire</a></h3>
+            <p>Entre sable et ciel, nous avons imaginé une palette inspirée des planches. Peintures écologiques, enduits protecteurs et conseils déco ont rendu à cet appartement sa douceur marine.</p>
             <div class="author"> <img src="images/author03.jpg" alt="Coloriste RenoGo"> <span>par <b>Élise, coloriste RenoGo</b></span> </div>
             <!-- end author -->
                          </div>
@@ -293,8 +293,8 @@
                         <img src="images/slide04.jpg" alt="Isolation combles à Bayeux">
                            </figure>
           <div class="content"> <small>19 février 2024</small>
-            <h3><a href="news-single.html">Bayeux : longère XVIIIᵉ passée en basse consommation</a></h3>
-            <p>Isolation chanvre-lin, étanchéité à l’air, pompe à chaleur hybride et suivi énergétique : la longère gagne 2 classes DPE et bénéficie désormais d’un contrat de maintenance RenoGo.</p>
+            <h3><a href="news-single.html">Bayeux : isolation biosourcée pour une longère du XVIIIe siècle</a></h3>
+            <p>La laine de bois et la ouate de cellulose ont enveloppé cette bâtisse pour préserver son patrimoine tout en réduisant les déperditions. Audit énergétique, tests d'étanchéité et suivi sur-mesure ont guidé chaque étape.</p>
             <div class="author"> <img src="images/author04.jpg" alt="Ingénieure RenoGo"> <span>par <b>Manon, ingénieure performance énergétique</b></span> </div>
             <!-- end author -->
                          </div>
@@ -307,8 +307,8 @@
                         <img src="images/slide05.jpg" alt="Maintenance préventive Le Havre">
                            </figure>
           <div class="content"> <small>9 février 2024</small>
-            <h3><a href="news-single.html">Le Havre : maintenance préventive 24/7 pour un siège face mer</a></h3>
-            <p>Éclairage, CVC, réseaux électriques et GTB sont désormais couverts par un contrat Maintenance 360°. Nos techniciens assurent des visites trimestrielles et une astreinte 24/7 pour garantir zéro interruption de service.</p>
+            <h3><a href="news-single.html">Le Havre : un plan de maintenance préventive pour des bureaux face à la mer</a></h3>
+            <p>Nos techniciens ont sécurisé l'éclairage, les réseaux électriques et la climatisation d'un immeuble tertiaire du quai Frissard. Objectif : zéro interruption de service et un confort durable pour les équipes.</p>
             <div class="author"> <img src="images/author05.jpg" alt="Responsable maintenance RenoGo"> <span>par <b>Arnaud, responsable maintenance</b></span> </div>
             <!-- end author -->
                          </div>
@@ -321,8 +321,8 @@
                         <img src="images/slide06.jpg" alt="Revêtement de sol Honfleur">
                            </figure>
           <div class="content"> <small>1 février 2024</small>
-            <h3><a href="news-single.html">Honfleur : concept-store d’art repensé de sol en plafond</a></h3>
-            <p>Parquet chêne fumé en bâtons rompus, dalles minérales haute résistance et éclairage galerie permettent à ce commerce d’art de valoriser les œuvres tout en facilitant les flux visiteurs.</p>
+            <h3><a href="news-single.html">Honfleur : parquet chêne fumé et dalle minérale pour un commerce d'art</a></h3>
+            <p>Pour accueillir les artistes locaux, nous avons mixé parquet chêne fumé et dalles minérales résistantes. La pose à bâtons rompus capte la lumière du port tout en fluidifiant la circulation des visiteurs.</p>
             <div class="author"> <img src="images/author06.jpg" alt="Designer d'intérieur RenoGo"> <span>par <b>Sarah, designer d'intérieur</b></span> </div>
             <!-- end author -->
                          </div>
@@ -335,8 +335,8 @@
                         <img src="images/slide07.jpg" alt="Potager partagé Cherbourg">
                            </figure>
           <div class="content"> <small>23 janvier 2024</small>
-            <h3><a href="news-single.html">Cherbourg : potager partagé et bien-être au travail</a></h3>
-            <p>Sur une zone d’activités, nous avons conçu un potager partagé avec arrosage connecté, éclairage LED et mobilier éco-conçu. Les collaborateurs y animent désormais ateliers RSE et pauses déconnectées.</p>
+            <h3><a href="news-single.html">Cherbourg : un potager partagé pour reconnecter les collaborateurs</a></h3>
+            <p>Dans une zone d'activités, RenoGo a créé un potager collectif, arrosé par récupération d'eau de pluie et éclairé en basse consommation. Les équipes y cultivent désormais tomates et cohésion.</p>
             <div class="author"> <img src="images/author07.jpg" alt="Chef d'équipe espaces verts"> <span>par <b>Julien, chef d'équipe espaces verts</b></span> </div>
             <!-- end author -->
                          </div>
@@ -349,8 +349,8 @@
                         <img src="images/slide08.jpg" alt="Salle de réunion modernisée à Évreux">
                            </figure>
           <div class="content"> <small>15 janvier 2024</small>
-            <h3><a href="news-single.html">Évreux : salle de réunion modulable et hybride</a></h3>
-            <p>Cloisons amovibles, isolation acoustique, système multimédia plug &amp; play et mobilier flexible offrent aux équipes une expérience de réunion hybride, sur site ou à distance.</p>
+            <h3><a href="news-single.html">Évreux : cloisonnement modulaire et acoustique soignée dans une salle de réunion</a></h3>
+            <p>Nous avons installé des cloisons amovibles, une isolation phonique renforcée et un système multimédia intuitif. Les réunions hybrides gagnent en confort et les équipes profitent d'une flexibilité totale.</p>
             <div class="author"> <img src="images/author08.jpg" alt="Expert cloisonnement RenoGo"> <span>par <b>Olivier, expert cloisonnement</b></span> </div>
             <!-- end author -->
                          </div>
@@ -363,8 +363,8 @@
                         <img src="images/slide09.jpg" alt="Façade ravalée à Fécamp">
                            </figure>
           <div class="content"> <small>8 janvier 2024</small>
-            <h3><a href="news-single.html">Fécamp : façade protégée et isolation extérieure performante</a></h3>
-            <p>Enduit respirant, ITE biosourcée et VMC double flux protègent cette copropriété face aux embruns. Le bâtiment réduit ses consommations de 28&nbsp;% et prépare son audit énergétique réglementaire.</p>
+            <h3><a href="news-single.html">Fécamp : ravalement et isolation extérieure face aux embruns</a></h3>
+            <p>Sur le front de mer, RenoGo a protégé une copropriété grâce à un enduit respirant, une isolation extérieure performante et une ventilation repensée. Le bâtiment résiste désormais aux embruns tout en économisant l'énergie.</p>
             <div class="author"> <img src="images/author09.jpg" alt="Façadier RenoGo"> <span>par <b>Hugo, façadier</b></span> </div>
             <!-- end author -->
                          </div>
@@ -377,8 +377,8 @@
                         <img src="images/slide10.jpg" alt="Maison connectée à Lisieux">
                            </figure>
           <div class="content"> <small>20 décembre 2023</small>
-            <h3><a href="news-single.html">Lisieux : maison connectée et économe pour une famille</a></h3>
-            <p>Alarme centralisée, chauffage pièce par pièce, volets pilotés et scénarios lumineux. La famille suit ses consommations en temps réel et profite d’un confort sur-mesure.</p>
+            <h3><a href="news-single.html">Lisieux : maison connectée et sécurisée pour une famille nombreuse</a></h3>
+            <p>Alarme centralisée, gestion du chauffage pièce par pièce et scénarios lumineux : la domotique RenoGo accompagne les allers-retours domicile-école. Les parents pilotent tout depuis leur smartphone en un geste.</p>
             <div class="author"> <img src="images/author10.jpg" alt="Conseillère smart home"> <span>par <b>Anaïs, conseillère smart home</b></span> </div>
             <!-- end author -->
                          </div>
@@ -391,8 +391,8 @@
                         <img src="images/slide11.jpg" alt="Chantier d'urgence à Granville">
                            </figure>
           <div class="content"> <small>12 décembre 2023</small>
-            <h3><a href="news-single.html">Granville : astreinte électrique pour relancer une PME en 24 h</a></h3>
-            <p>Après une tempête, nos techniciens ont sécurisé l’alimentation, installé un tableau provisoire et remis en production une PME agroalimentaire en moins d’une journée grâce à notre cellule d’urgence.</p>
+            <h3><a href="news-single.html">Granville : intervention corrective express après une tempête</a></h3>
+            <p>Suite à une coupure électrique, nos équipes d'astreinte ont sécurisé les installations, remplacé le tableau et rétabli la production d'une PME agroalimentaire en 24 heures chrono.</p>
             <div class="author"> <img src="images/author11.jpg" alt="Technicien astreinte RenoGo"> <span>par <b>Yanis, technicien astreinte</b></span> </div>
             <!-- end author -->
                          </div>
@@ -419,13 +419,13 @@
                                 <div class="widget">
                                 <h6 class="widget-title">CATÉGORIES</h6>
                                 <ul class="categories">
-                                                <li><a href="#">Jardin & Paysage durable</a></li>
-                                                <li><a href="#">Énergie & Smart Building</a></li>
-                                                <li><a href="#">Design & Ergonomie</a></li>
-                                                <li><a href="#">Isolation & Performance</a></li>
-                                                <li><a href="#">Sols & Revêtements techniques</a></li>
-                                                <li><a href="#">Maintenance & Facility Management</a></li>
-                                                <li><a href="#">Interventions d'urgence</a></li>
+                                                <li><a href="#">Jardinage & Paysage</a></li>
+                                                <li><a href="#">Électricité & Domotique</a></li>
+                                                <li><a href="#">Peinture & Décoration</a></li>
+                                                <li><a href="#">Cloisons & Isolation</a></li>
+                                                <li><a href="#">Revêtements de sol</a></li>
+                                                <li><a href="#">Maintenance préventive</a></li>
+                                                <li><a href="#">Chantiers d'urgence</a></li>
                                         </ul>
                                 </div>
                                 <!-- end widget -->
@@ -456,8 +456,8 @@
       <div class="col-12">
 
           <figure class="logo"> <img src="images/logo.png" alt="RenoGo"> </figure>
-          <h2>Anticipez vos projets grâce aux experts <b>RenoGo</b></h2>
-          <a href="contact.html" class="button">PROGRAMMER UN ÉCHANGE <i class="lni lni-arrow-right"></i></a>
+          <h2>Vivez <b>mieux</b> et <b>plus serein</b> avec RenoGo</h2>
+          <a href="contact.html" class="button">OBTENIR UN DEVIS <i class="lni lni-arrow-right"></i></a>
                   <div class="sales-representive">
                         <figure>
                                 <img src="images/author12.jpg" alt="Conseiller RenoGo">
@@ -491,7 +491,7 @@
       <!-- end col-6 -->
                 <div class="col-lg-6">
         <h6 class="widget-title">INSCRIPTION</h6>
-       <p>Recevez nos études de cas, alertes aides financières et offres exclusives pour vos sites en Normandie & Île-de-France.</p>
+       <p>Recevez nos conseils saisonniers et offres exclusives.</p>
                         <form>
                         <input type="email" placeholder="Votre e-mail">
                                 <input type="submit" value="JE M'INSCRIS">
@@ -500,7 +500,7 @@
       <!-- end col-6 -->
                 <div class="col-12">
                         <div class="footer-bottom">
-                        <span>© 2024 RenoGo | Rénovation, maintenance et aménagements en Normandie &amp; Île-de-France</span>
+                                <span>© 2024 RenoGo | Rénovation, maintenance et aménagements en Normandie</span>
                                 <ul>
                                 <li><a href="#">Facebook</a></li>
                                 <li><a href="#">Instagram</a></li>

--- a/projects.html
+++ b/projects.html
@@ -6,8 +6,8 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <!-- Primary SEO -->
-  <title>RenoGo • Réalisations et projets de rénovation en Normandie & Île-de-France</title>
-  <meta name="description" content="Explorez les réalisations RenoGo : bureaux ergonomiques, habitats rénovés, jardins durables et maintenance multi-technique pour entreprises et particuliers entre Normandie et Île-de-France.">
+  <title>RenoGo • Rénovation intérieure & amélioration de l’habitat en France</title>
+  <meta name="description" content="RenoGo rénove et transforme appartements et maisons : cuisines, salles de bain, isolation, électricité, peinture. Devis rapide, travaux qualitatifs, livrés à temps.">
   <link rel="canonical" href="https://www.renogo.fr/">
 
   <!-- Indexing -->
@@ -29,8 +29,8 @@
   <meta property="og:locale" content="fr_FR">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="RenoGo">
-  <meta property="og:title" content="RenoGo • Projets de rénovation et maintenance">
-  <meta property="og:description" content="Études de cas : bureaux ergonomiques, habitats durables, smart building et jardins responsables en Normandie & Île-de-France.">
+  <meta property="og:title" content="RenoGo • Rénovation intérieure & amélioration de l’habitat">
+  <meta property="og:description" content="Cuisine, salle de bain, peinture, isolation et plus. Devis rapide, travaux maîtrisés.">
   <meta property="og:url" content="https://www.renogo.fr/">
   <meta property="og:image" content="https://www.renogo.fr/assets/og/renogo-cover.jpg">
   <meta property="og:image:width" content="1200">
@@ -39,8 +39,8 @@
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@renogo">
-  <meta name="twitter:title" content="RenoGo • Projets de rénovation et maintenance">
-  <meta name="twitter:description" content="Découvrez nos chantiers pilotes pour entreprises et particuliers entre Paris et la Normandie.">
+  <meta name="twitter:title" content="RenoGo • Rénovation intérieure & amélioration de l’habitat">
+  <meta name="twitter:description" content="Rénovation d’appartements et maisons en France. Devis rapide, délais tenus.">
   <meta name="twitter:image" content="https://www.renogo.fr/assets/og/renogo-cover.jpg">
 
   <!-- Organization -->
@@ -75,7 +75,7 @@
     "url": "https://www.renogo.fr/",
     "logo": "https://www.renogo.fr/assets/logo/renogo-logo.svg",
     "image": "https://www.renogo.fr/assets/og/renogo-cover.jpg",
-    "description": "Rénovation de bureaux, habitats et jardins, maintenance multi-technique et smart building.",
+    "description": "Rénovation intérieure d’appartements et maisons : cuisines, salles de bain, isolation, électricité, peinture.",
     "telephone": "+33-1-23-45-67-89",
     "areaServed": "FR",
     "priceRange": "€€",
@@ -144,10 +144,10 @@
 
     <div class="hide-mobile">
       <p>
-        RenoGo pilote vos projets de rénovation et de maintenance en Normandie &amp; Île-de-France :
-        <u>électricité &amp; éclairage</u>, <u>peinture &amp; sols</u>, <u>plomberie &amp; CVC</u>,
-        <u>jardinage &amp; aménagement paysager</u> et <u>domotique / smart building</u>.
-        Des chantiers propres, des délais tenus et un suivi de proximité.
+        RenoGo accompagne vos projets de rénovation et d’entretien en Normandie :
+        <u>électricité & éclairage</u>, <u>peinture & sols</u>, <u>cloisons & isolation</u>,
+        <u>jardinage & aménagement paysager</u>, ainsi que <u>domotique / maison intelligente</u>.
+        Des chantiers propres, des délais tenus, un suivi de proximité.
       </p>
 
       <figure class="gallery">
@@ -236,7 +236,7 @@
   <header class="page-header">
     <div class="container">
       <h1>Projets</h1>
-      <h6>Des scénarios réels menés entre Paris et la Normandie pour inspirer vos futures transformations professionnelles et résidentielles.</h6>
+      <h6>Des scénarios réels conçus avec nos clients normands pour préparer vos futurs chantiers, même sans photos avant/après… pour l'instant.</h6>
       <ul>
         <li><a href="index.html">Accueil</a></li>
         <li>Projets</li>
@@ -251,12 +251,14 @@
       <div class="row align-items-center mb-5">
         <div class="col-lg-6">
           <div class="section-title">
-            <h2>Pourquoi découvrir nos projets avant de lancer le vôtre&nbsp;?</h2>
+            <h2>Pourquoi parler de projets avant la première pierre&nbsp;?</h2>
           </div>
         </div>
         <div class="col-lg-6">
           <p>
-            Parce qu’un plateau de bureaux à La Défense ou une maison de famille à Cabourg ne se rénove pas au hasard. Nous préparons chaque opération en amont : diagnostics réglementaires, scénarios énergétiques, design d’usages et phasage travaux pour limiter l’impact sur votre activité. Découvrez nos projets pilotes et inspirez-vous de nos retours d’expérience.
+            Parce que chaque maison normande, chaque bureau avec vue sur la Manche ou la Seine, mérite une préparation millimétrée.
+            RenoGo travaille en amont sur la faisabilité, les autorisations, le choix des matériaux résistants à l'air marin ou à l'humidité du bocage.
+            Nous partageons ici nos inspirations et projets pilotes afin que vous puissiez vous projeter avec confiance.
           </p>
         </div>
       </div>
@@ -266,21 +268,21 @@
           <div class="icon-content">
             <figure><img src="images/icon01.png" alt="Études personnalisées"></figure>
             <h3>Études personnalisées</h3>
-            <small>Audits techniques, relevés 3D et business case ROI pour Paris, Nanterre, Rouen, Caen ou Cherbourg.</small>
+            <small>Diagnostics techniques, relevés 3D et estimations budgétaires pour Caen, Rouen, Alençon ou Cherbourg.</small>
           </div>
         </div>
         <div class="col-md-4">
           <div class="icon-content">
             <figure><img src="images/icon02.png" alt="Artisans sélectionnés"></figure>
-            <h3>Artisans & techniciens labellisés</h3>
-            <small>Réseau RGE, Qualifelec, QualiClima et ergonomes partenaires, pilotés par un chef de projet unique.</small>
+            <h3>Artisans sélectionnés</h3>
+            <small>Un réseau de partenaires normands certifiés RGE, Qualifelec ou QualiPaysage, coordonnés par nos chefs de projet.</small>
           </div>
         </div>
         <div class="col-md-4">
           <div class="icon-content">
             <figure><img src="images/icon03.png" alt="Suivi digital"></figure>
             <h3>Suivi digital</h3>
-            <small>Planning partagé, KPI chantiers, reporting ESG et domotique prête à configurer depuis votre smartphone.</small>
+            <small>Planning partagé, comptes rendus hebdomadaires et domotique prête à configurer depuis votre smartphone.</small>
           </div>
         </div>
       </div>
@@ -306,7 +308,7 @@
                 </a>
                 <figcaption>
                   <h5>Granville • Jardin côtier résilient</h5>
-                  <p>Aménagement paysager pour un siège social face mer : terrasse bois, zones de travail outdoor, arrosage connecté et éclairage LED basse consommation.</p>
+                  <p>Création d'une oasis vivace résistante aux embruns, terrasse en bois thermo-traité et éclairage LED basse consommation pour prolonger les soirées face à la mer.</p>
                   <span>Statut : études de sol validées, démarrage au printemps</span>
                 </figcaption>
               </figure>
@@ -320,7 +322,7 @@
                 </a>
                 <figcaption>
                   <h5>Deauville • Villa secondaire connectée</h5>
-                  <p>Modernisation d’une villa pour télétravail : GTB résidentielle, scénarios lumineux, sécurité périmétrique, bornes de recharge et monitoring énergétique à distance.</p>
+                  <p>Installation domotique complète : chauffage pilotable, scénarios lumineux doux pour les week-ends, sécurité périmétrique et bornes de recharge discrètes.</p>
                   <span>Statut : sélection des équipements smart home en cours</span>
                 </figcaption>
               </figure>
@@ -334,7 +336,7 @@
                 </a>
                 <figcaption>
                   <h5>Rouen • Maison de ville lumineuse</h5>
-                  <p>Rénovation d’un duplex pour un couple de cadres : peintures minérales, parquet acoustique, rangements sur-mesure et câblage réseau pour home office.</p>
+                  <p>Peintures minérales respirantes, mise en valeur des moulures, parquet chêne clair et optimisation acoustique pour un couple de télétravailleurs.</p>
                   <span>Statut : palettes couleurs validées, pose prévue cet été</span>
                 </figcaption>
               </figure>
@@ -348,7 +350,7 @@
                 </a>
                 <figcaption>
                   <h5>Bayeux • Longère basse consommation</h5>
-                  <p>Transformation d’une longère en chambres d’hôtes premium : isolation chanvre-lin, planchers chauffants, ventilation double flux et monitoring énergétique.</p>
+                  <p>Isolation biosourcée chanvre-lin, cloisons phonique pour les chambres d'hôtes et planchers chauffants hydrauliques reliés à une pompe à chaleur.</p>
                   <span>Statut : dossiers aides énergie déposés</span>
                 </figcaption>
               </figure>
@@ -362,7 +364,7 @@
                 </a>
                 <figcaption>
                   <h5>Caen • Cour végétalisée &amp; potager urbain</h5>
-                  <p>Reconversion d’une cour de coworking : patios collaboratifs, potagers partagés, récupérateur d’eau et mobilier bois issu des forêts normandes.</p>
+                  <p>Transformation d'une cour bétonnée en havre comestible : carrés potagers, récupération d'eau de pluie et clôtures bois fabriquées à Lisieux.</p>
                   <span>Statut : calendrier plantations établi avec notre paysagiste</span>
                 </figcaption>
               </figure>
@@ -376,7 +378,7 @@
                 </a>
                 <figcaption>
                   <h5>Le Havre • Bureaux intelligents</h5>
-                  <p>Refonte d’un plateau logistique : relamping LED, détection de présence, pilotage GTB, mobilier ergonomique et contrat de maintenance multi-technique.</p>
+                  <p>Relamping LED, détection de présence, prises connectées et maintenance préventive centralisée pour un siège social près des docks.</p>
                   <span>Statut : audit énergétique terminé, lot électricité en lancement</span>
                 </figcaption>
               </figure>
@@ -390,7 +392,7 @@
                 </a>
                 <figcaption>
                   <h5>Cherbourg • Suite parentale apaisante</h5>
-                  <p>Création d’une suite parentale avec salle d’eau : peintures naturelles, tête de lit sur-mesure, éclairage biorythmique et isolation acoustique.</p>
+                  <p>Peinture aux pigments naturels, tête de lit sur-mesure, éclairage indirect et isolation phonique des cloisons pour des nuits bercées par la mer.</p>
                   <span>Statut : menuiseries en fabrication dans nos ateliers partenaires</span>
                 </figcaption>
               </figure>
@@ -403,8 +405,8 @@
                   <img src="images/slide02.jpg" alt="Perspective d'un hall d'immeuble rénové à Évreux">
                 </a>
                 <figcaption>
-                  <h5>Évreux • Copropriété sécurisée</h5>
-                  <p>Modernisation d’un immeuble mixte : conformité électrique, cloisons coupe-feu, sols grand trafic, accessibilité PMR et contrat de maintenance annuel.</p>
+                  <h5>Évreux • Immeuble copropriété sereine</h5>
+                  <p>Remise aux normes électriques, reprise des cloisons coupe-feu, revêtements de sol grand passage et plan de maintenance annuel.</p>
                   <span>Statut : vote des copropriétaires obtenu à l'unanimité</span>
                 </figcaption>
               </figure>
@@ -430,7 +432,9 @@
         </div>
         <div class="col-lg-7">
           <p>
-            Avant le premier coup de pinceau, nous structurons la gouvernance du projet : plateforme digitale, assurance décennale, interlocuteur unique, visites de contrôle hebdomadaires et reporting ESG. Chaque cas présenté est sécurisé par un calendrier détaillé et des devis fermes validés avec nos partenaires certifiés.
+            Avant même le premier coup de pinceau, nous engageons une relation de confiance : comptes rendus partagés,
+            assurance décennale, interlocuteur unique, visites de contrôle hebdomadaires.
+            Chaque projet présenté ici est déjà sécurisé par un calendrier détaillé et des devis fermes validés avec nos partenaires.
           </p>
         </div>
       </div>
@@ -439,11 +443,11 @@
           <div class="icon-content">
             <h3>Process en 5 étapes</h3>
             <ul>
-              <li>1. Rendez-vous inspiration sur site ou en visio avec nos équipes Paris/Normandie.</li>
-              <li>2. Relevés techniques, modélisation 3D et audits énergétiques.</li>
-              <li>3. Consultation artisans/techniciens certifiés et consolidation des devis fermes.</li>
-              <li>4. Planification multi-lots, suivi logistique et communication chantier.</li>
-              <li>5. Réception contrôlée, dossier DOE digital et maintenance programmée.</li>
+              <li>1. Rendez-vous inspiration chez vous ou en visio depuis Paris.</li>
+              <li>2. Relevés techniques et modélisation 3D pour anticiper chaque détail.</li>
+              <li>3. Consultation des artisans normands et consolidation des devis.</li>
+              <li>4. Planification des travaux par lot, suivi des approvisionnements.</li>
+              <li>5. Réception contrôlée et maintenance préventive programmée.</li>
             </ul>
           </div>
         </div>
@@ -451,11 +455,11 @@
           <div class="icon-content">
             <h3>Vos bénéfices concrets</h3>
             <ul>
-              <li>Délais sécurisés grâce à notre hub logistique de Pont-l'Évêque et notre entrepôt francilien.</li>
-              <li>Démarches administratives (DP, CEE, MaPrimeRénov', autorisations ERP) prises en charge.</li>
-              <li>Matériaux durables : anti-corrosion, anti-humidité, acoustique et biosourcés.</li>
-              <li>Budget maîtrisé avec suivi temps réel et arbitrages budgétaires partagés.</li>
-              <li>Service après-vente : visites saisonnières, maintenance CVC et assistance occupants.</li>
+              <li>Délais réalistes grâce à une logistique depuis notre hub de Pont-l'Évêque.</li>
+              <li>Démarches administratives (DP, CEE, aides MaPrimeRénov') prises en charge.</li>
+              <li>Matériaux adaptés au climat normand : anti-corrosion, anti-humidité, essences locales.</li>
+              <li>Budget maîtrisé avec un suivi des dépenses en temps réel.</li>
+              <li>Service après-vente : visites saisonnières jardin &amp; maintenance électrique.</li>
             </ul>
           </div>
         </div>
@@ -468,8 +472,8 @@
       <div class="row">
         <div class="col-12 text-center">
           <figure class="logo"><img src="images/logo.png" alt="Logo RenoGo"></figure>
-          <h2>Imaginons ensemble le futur de vos espaces en Normandie & Île-de-France</h2>
-          <a href="contact.html" class="button">PLANIFIER UN RENDEZ-VOUS STRATÉGIQUE <i class="lni lni-arrow-right"></i></a>
+          <h2>Imaginons ensemble le futur de votre bien normand</h2>
+          <a href="contact.html" class="button">PLANIFIER UN RENDEZ-VOUS <i class="lni lni-arrow-right"></i></a>
           <div class="sales-representive">
             <figure>
               <img src="images/author01.jpg" alt="Conseiller RenoGo">
@@ -502,7 +506,7 @@
         <!-- end col-6 -->
         <div class="col-lg-6">
           <h6 class="widget-title">RESTONS EN CONTACT</h6>
-          <p>Recevez nos études de cas, insights énergie et offres exclusives pour vos projets en Normandie & Île-de-France.</p>
+          <p>Recevez nos conseils saisonniers et nos offres exclusives pour vos projets en Normandie.</p>
           <form>
             <input type="email" placeholder="Votre e-mail">
             <input type="submit" value="S'INSCRIRE">
@@ -511,7 +515,7 @@
         <!-- end col-6 -->
         <div class="col-12">
           <div class="footer-bottom">
-            <span>© 2024 RenoGo | Rénovation, entretien et maintenance en Normandie &amp; Île-de-France</span>
+            <span>© 2024 RenoGo | Rénovation, entretien et maintenance en Normandie</span>
             <ul>
               <li><a href="#">Facebook</a></li>
               <li><a href="#">Instagram</a></li>

--- a/services.html
+++ b/services.html
@@ -6,8 +6,8 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <!-- Primary SEO -->
-  <title>RenoGo • Services de rénovation et maintenance multi-technique en Normandie & Île-de-France</title>
-  <meta name="description" content="Découvrez les services RenoGo : rénovation de bureaux, modernisation d’habitats, maintenance multi-technique, ergonomie, smart building et efficacité énergétique pour entreprises et particuliers.">
+  <title>RenoGo • Rénovation intérieure & amélioration de l’habitat en France</title>
+  <meta name="description" content="RenoGo rénove et transforme appartements et maisons : cuisines, salles de bain, isolation, électricité, peinture. Devis rapide, travaux qualitatifs, livrés à temps.">
   <link rel="canonical" href="https://www.renogo.fr/">
 
   <!-- Indexing -->
@@ -29,8 +29,8 @@
   <meta property="og:locale" content="fr_FR">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="RenoGo">
-  <meta property="og:title" content="RenoGo • Solutions de rénovation et maintenance 360°">
-  <meta property="og:description" content="Pilotage de travaux, services multi-techniques, ergonomie et smart building pour entreprises et particuliers en Normandie & Île-de-France.">
+  <meta property="og:title" content="RenoGo • Rénovation intérieure & amélioration de l’habitat">
+  <meta property="og:description" content="Cuisine, salle de bain, peinture, isolation et plus. Devis rapide, travaux maîtrisés.">
   <meta property="og:url" content="https://www.renogo.fr/">
   <meta property="og:image" content="https://www.renogo.fr/assets/og/renogo-cover.jpg">
   <meta property="og:image:width" content="1200">
@@ -39,8 +39,8 @@
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@renogo">
-  <meta name="twitter:title" content="RenoGo • Solutions de rénovation et maintenance 360°">
-  <meta name="twitter:description" content="Bureaux, habitats, maintenance et efficacité énergétique pilotés par RenoGo entre Normandie et Île-de-France.">
+  <meta name="twitter:title" content="RenoGo • Rénovation intérieure & amélioration de l’habitat">
+  <meta name="twitter:description" content="Rénovation d’appartements et maisons en France. Devis rapide, délais tenus.">
   <meta name="twitter:image" content="https://www.renogo.fr/assets/og/renogo-cover.jpg">
 
   <!-- Organization -->
@@ -75,7 +75,7 @@
     "url": "https://www.renogo.fr/",
     "logo": "https://www.renogo.fr/assets/logo/renogo-logo.svg",
     "image": "https://www.renogo.fr/assets/og/renogo-cover.jpg",
-    "description": "Rénovation de bureaux et logements, maintenance multi-technique, smart building et efficacité énergétique.",
+    "description": "Rénovation intérieure d’appartements et maisons : cuisines, salles de bain, isolation, électricité, peinture.",
     "telephone": "+33-1-23-45-67-89",
     "areaServed": "FR",
     "priceRange": "€€",
@@ -144,10 +144,10 @@
 
     <div class="hide-mobile">
       <p>
-        RenoGo pilote vos projets de rénovation et de maintenance en Normandie &amp; Île-de-France :
-        <u>électricité &amp; éclairage</u>, <u>peinture &amp; sols</u>, <u>plomberie &amp; CVC</u>,
-        <u>jardinage &amp; aménagement paysager</u> et <u>domotique / smart building</u>.
-        Des chantiers propres, des délais tenus et un suivi de proximité.
+        RenoGo accompagne vos projets de rénovation et d’entretien en Normandie :
+        <u>électricité & éclairage</u>, <u>peinture & sols</u>, <u>cloisons & isolation</u>,
+        <u>jardinage & aménagement paysager</u>, ainsi que <u>domotique / maison intelligente</u>.
+        Des chantiers propres, des délais tenus, un suivi de proximité.
       </p>
 
       <figure class="gallery">
@@ -235,7 +235,7 @@
 <header class="page-header">
   <div class="container">
     <h1>Services</h1>
-    <h6>Des solutions sur mesure pour rénover, équiper et maintenir bureaux, coworkings et habitats normands.</h6>
+    <h6>De la première visite à l'entretien sur le long terme, RenoGo orchestre chaque détail pour vos espaces de vie et de travail.</h6>
     <ul>
       <li><a href="index.html">Accueil</a></li>
       <li>Services</li>
@@ -249,25 +249,25 @@
     <div class="row">
       <div class="col-lg-4">
         <div class="icon-content">
-          <figure><img src="images/icon01.png" alt="Services essentiels RenoGo"></figure>
-          <h3>Piliers essentiels</h3>
-          <small>Peinture, électricité, plomberie, chauffage-climatisation : la base solide pour moderniser vos espaces pros et résidentiels.</small> <a href="#services-essentiels">+</a> </div>
+          <figure><img src="images/icon01.png" alt="Proximité terrain"></figure>
+          <h3>Experts de proximité</h3>
+          <small>Nos chefs de projet sillonnent la Normandie pour une réponse rapide et personnalisée à Caen, Rouen, Cherbourg ou Bayeux.</small> <a href="#services-jardin">+</a> </div>
         <!-- end icon-content -->
       </div>
       <!-- end col-4 -->
       <div class="col-lg-4">
         <div class="icon-content">
-          <figure><img src="images/icon02.png" alt="Services différenciants RenoGo"></figure>
-          <h3>Services différenciants</h3>
-          <small>Smart office, ergonomie, jardins responsables : des solutions qui créent du bien-être et boostent la productivité.</small> <a href="#services-differenciants">+</a> </div>
+          <figure><img src="images/icon02.png" alt="Innovation durable"></figure>
+          <h3>Durabilité & innovation</h3>
+          <small>Solutions bas carbone, domotique intuitive et matériaux certifiés pour un confort durable à la normande.</small> <a href="#services-electricite">+</a> </div>
         <!-- end icon-content -->
       </div>
       <!-- end col-4 -->
       <div class="col-lg-4">
         <div class="icon-content">
-          <figure><img src="images/icon03.png" alt="Programmes premium RenoGo"></figure>
-          <h3>Programmes premium</h3>
-          <small>Contrats de maintenance, rénovation globale et upgrades énergétiques pour sécuriser votre patrimoine.</small> <a href="#programmes-premium">+</a> </div>
+          <figure><img src="images/icon03.png" alt="Suivi premium"></figure>
+          <h3>Suivi clé en main</h3>
+          <small>Planning partagé, interlocuteur unique et maintenance préventive pour des chantiers sans surprises.</small> <a href="#accompagnement-renogo">+</a> </div>
         <!-- end icon-content -->
       </div>
       <!-- end col-4 -->
@@ -277,21 +277,21 @@
   <!-- end container -->
 </section>
 <!-- end content-section -->
-<section class="content-section no-spacing" id="services-essentiels" data-background="images/section-bg02.jpg">
+<section class="content-section no-spacing" id="accompagnement-renogo" data-background="images/section-bg02.jpg">
   <div class="container">
     <div class="row justify-content-end">
       <div class="col-lg-6 col-md-9">
         <div class="services-list-box">
-          <h4>Piliers essentiels : rénovation multi-technique</h4>
-          <p>Notre task force regroupe peintres, électriciens, plombiers, climaticiens et chefs de projet. Nous modernisons vos plateaux tertiaires, appartements et maisons tout en assurant la sécurité et la conformité réglementaire.</p>
+          <h4>Un partenaire unique pour vos espaces</h4>
+          <p>Notre équipe pluridisciplinaire s'engage auprès des particuliers, syndics et entreprises pour transformer et entretenir les biens normands. Chaque mission commence par une immersion sur site, l'écoute de vos usages et la co-construction d'une feuille de route opérationnelle.</p>
           <ul>
-            <li>Peinture intérieure/extérieure, finitions décoratives et protections anti-humidité</li>
-            <li>Électricité et éclairage : mises aux normes, bornes de recharge, sécurité incendie</li>
-            <li>Plomberie, salles d’eau, cuisines professionnelles et sanitaires PMR</li>
-            <li>Chauffage, climatisation et ventilation à haute efficacité énergétique</li>
-            <li>Suivi qualité, garanties décennales et service après-travaux proactif</li>
+            <li>Visite conseil et audit technique offerts sur Caen, Rouen et Le Havre</li>
+            <li>Pilotage de projets avec planning, budget et reporting transparent</li>
+            <li>Maintenance préventive et dépannage 6j/7 avec astreinte hivernale</li>
+            <li>Matériaux sélectionnés pour résister au climat marin normand</li>
+            <li>Garanties décennales et service après-travaux proactif</li>
           </ul>
-          <a href="contact.html" class="button">PLANIFIER UN AUDIT TECHNIQUE</a> </div>
+          <a href="contact.html" class="button">DEMANDER UN DIAGNOSTIC</a> </div>
         <!-- end services-list-box -->
       </div>
       <!-- end col-6 -->
@@ -306,8 +306,8 @@
     <div class="row">
       <div class="col-lg-3 col-md-6">
         <div class="counter-box"> <span class="odometer" data-count="120" data-status="yes">0</span> <span class="value">+</span>
-          <h6>Chantiers annuels en Normandie & Île-de-France</h6>
-          <p>Modernisation de bureaux, coworkings, habitats familiaux et résidences secondaires pilotée chaque année.</p>
+          <h6>Chantiers annuels en Normandie</h6>
+          <p>Maisons anciennes, villas balnéaires, locaux tertiaires et commerces accompagnés chaque année.</p>
         </div>
         <!-- end counter-box -->
       </div>
@@ -315,7 +315,7 @@
       <div class="col-lg-3 col-md-6">
         <div class="counter-box"> <span class="odometer" data-count="48" data-status="yes">0</span> <span class="value">h</span>
           <h6>Délai moyen d'intervention</h6>
-          <p>Jusqu’à 48 h pour sécuriser un site stratégique grâce à nos équipes itinérantes et notre stock tampon.</p>
+          <p>Une organisation agile pour sécuriser vos biens même en période de tempête ou de fortes marées.</p>
         </div>
         <!-- end counter-box -->
       </div>
@@ -323,7 +323,7 @@
       <div class="col-lg-3 col-md-6">
         <div class="counter-box"> <span class="odometer" data-count="87" data-status="yes">0</span> <span class="value">%</span>
           <h6>Clients fidèles</h6>
-          <p>SME, bailleurs, syndics et familles nous renouvellent leur confiance année après année.</p>
+          <p>Familles, bailleurs sociaux et PME nous confient leurs projets sur le long terme.</p>
         </div>
         <!-- end counter-box -->
       </div>
@@ -331,7 +331,7 @@
       <div class="col-lg-3 col-md-6">
         <div class="counter-box"> <span class="odometer" data-count="5" data-status="yes">0</span> <span class="value"> métiers</span>
           <h6>Compétences complémentaires</h6>
-          <p>Équipes intégrant ingénierie CVC, second œuvre, paysagisme, smart building et facility management.</p>
+          <p>Jardin, électricité, peinture, cloisons & isolation, sols : un bouquet de services coordonnés.</p>
         </div>
         <!-- end counter-box -->
       </div>
@@ -347,14 +347,14 @@
     <div class="row">
       <div class="col-lg-7">
         <div class="section-title text-left">
-          <h6>MÉTHODE RENOGO</h6>
-          <h2>Une approche data-driven pour des chantiers performants</h2>
+          <h6>NOTRE MÉTHODOLOGIE</h6>
+          <h2>Une approche en trois temps pour un résultat impeccable</h2>
         </div>
         <!-- end section-title -->
       </div>
       <!-- end col-7 -->
       <div class="col-lg-5">
-        <p>Nous combinons audits techniques, design thinking et pilotage digital pour anticiper chaque détail. Notre connaissance des sites tertiaires franciliens et des architectures normandes garantit des réalisations durables.</p>
+        <p>Chaque projet RenoGo s'écrit avec vous : diagnostic précis, design sur mesure, exécution millimétrée et suivi préventif. Notre connaissance des architectures normandes, de la météo côtière et des contraintes énergétiques garantit des chantiers pérennes.</p>
       </div>
       <!-- end col-5 -->
       <div class="col-lg-4">
@@ -362,8 +362,8 @@
           <figure class="image"><img src="images/step01.jpg" alt="Étape 1"></figure>
           <div class="content"> <span>01.</span>
             <figure class="icon"><img src="images/icon01.png" alt="Audit"></figure>
-            <h6>Analyse & stratégie</h6>
-            <p>Diagnostic énergétique, cartographie des usages, benchmark confort et recommandations budgétaires.</p>
+            <h6>Analyse & inspiration</h6>
+            <p>Relevés techniques, inspirations locales, sélection de matériaux adaptés aux embruns et à l'humidité.</p>
           </div>
           <!-- end content -->
         </div>
@@ -376,7 +376,7 @@
           <div class="content"> <span>02.</span>
             <figure class="icon"><img src="images/icon02.png" alt="Planification"></figure>
             <h6>Conception & planification</h6>
-            <p>Scénarios immersifs 3D, sélection matériaux bas carbone, phasage pour limiter l'arrêt d'activité.</p>
+            <p>Scénarios 3D, choix de couleurs et éclairages, phasage des corps d'état pour limiter l'immobilisation.</p>
           </div>
           <!-- end content -->
         </div>
@@ -389,7 +389,7 @@
           <div class="content"> <span>03.</span>
             <figure class="icon"><img src="images/icon03.png" alt="Suivi"></figure>
             <h6>Réalisation & entretien</h6>
-            <p>Chefs de chantier connectés, contrôles qualité, réception digitale et contrat de maintenance évolutif.</p>
+            <p>Équipes qualifiées, contrôles qualité continus et mise en place d'un contrat d'entretien saisonnier.</p>
           </div>
           <!-- end content -->
         </div>
@@ -402,12 +402,12 @@
   <!-- end container -->
 </section>
 <!-- end content-section -->
-<section class="content-section no-spacing" id="services-differenciants">
+<section class="content-section no-spacing">
   <div class="container">
     <div class="row align-items-center no-gutters">
       <div class="col-lg-5">
         <div class="tab-left">
-          <h2>Services différenciants pour créer des expériences inspirantes</h2>
+          <h2>Des expertises complémentaires pour un chantier harmonieux</h2>
           <ul class="tab-nav">
             <li class="active"><a href="#tab01" id="services-jardin">Jardin & Paysage</a></li>
             <li><a href="#tab02" id="services-electricite">Électricité & Smart Home</a></li>
@@ -415,7 +415,7 @@
             <li><a href="#tab04">Cloisons, Plâtrerie & Isolation</a></li>
             <li><a href="#tab05">Sols & Revêtements</a></li>
           </ul>
-          <p>Nous combinons design, ergonomie et technologie pour transformer vos lieux de vie et de travail. Chaque lot est piloté par un expert métier pour garantir confort, bien-être et identité de marque.</p>
+          <p>Nos équipes partagent une même exigence : préserver le cachet normand tout en intégrant les innovations qui simplifient le quotidien. Chaque lot est orchestré par un conducteur de travaux dédié pour que tout s'enchaine naturellement.</p>
         </div>
         <!-- end tab-left -->
       </div>
@@ -426,7 +426,7 @@
             <img src="images/tab01.jpg" alt="Aménagement paysager">
             <div class="tab-text">
               <h3>Respirer l'art de vivre normand</h3>
-              <p>Paysagisme pour sièges sociaux, résidences et hôtellerie : terrasses conviviales, patios végétalisés, jardins comestibles, entretien quatre saisons et arrosage connecté pour réduire la consommation d’eau.</p>
+              <p>Création de jardins côtiers résistants au sel, terrasses en bois traité, potagers familiaux et entretien annuel : tonte, taille douce, désherbage écologique, préparation aux tempêtes et installation d'arrosages connectés.</p>
             </div>
           </div>
           <!-- end tab01 -->
@@ -434,15 +434,15 @@
             <img src="images/tab02.jpg" alt="Installation électrique">
             <div class="tab-text">
               <h3>Énergie sécurisée & connectée</h3>
-              <p>Installations CFO/CFA, GTB, smart building, relamping LED, bornes de recharge, sécurité incendie et solutions IoT pour piloter vos consommations. Maintenance corrective et préventive 6j/7.</p>
+              <p>Mises aux normes, tableaux électriques intelligents, éclairages d'ambiance, bornes de recharge, alarmes et domotique pour piloter chauffage, volets et éclairage à distance. Service de maintenance corrective et préventive 6j/7.</p>
             </div>
           </div>
           <!-- end tab02 -->
           <div id="tab03" class="tab-item">
             <img src="images/tab03.jpg" alt="Travaux de peinture">
             <div class="tab-text">
-              <h3>Couleurs qui valorisent votre image</h3>
-              <p>Design coloriel, branding d’espaces, finitions premium, traitements anti-humidité, effets décoratifs et signalétique pour révéler la personnalité de vos bureaux et de vos intérieurs.</p>
+              <h3>Couleurs qui dialoguent avec la lumière normande</h3>
+              <p>Diagnostic des supports, traitement anti-humidité, peintures biosourcées, finitions décoratives, fresques contemporaines ou patines esprit maison de famille. Protection totale du mobilier et nettoyage minutieux en fin de chantier.</p>
             </div>
           </div>
           <!-- end tab03 -->
@@ -450,15 +450,15 @@
             <img src="images/tab04.jpg" alt="Isolation performante">
             <div class="tab-text">
               <h3>Confort thermique toute l'année</h3>
-              <p>Cloisons modulaires, isolation biosourcée, plafonds acoustiques, traitements coupe-feu pour ERP et optimisation énergétique éligible aux dispositifs d’aides.</p>
+              <p>Création de cloisons acoustiques, doublages isolants biosourcés, traitement des combles, solutions coupe-feu pour les ERP et optimisation des performances énergétiques pour bénéficier des aides locales.</p>
             </div>
           </div>
           <!-- end tab04 -->
           <div id="tab05" class="tab-item">
             <img src="images/tab05.jpg" alt="Pose de sols">
             <div class="tab-text">
-              <h3>Sols prêts pour un trafic intense</h3>
-              <p>Parquets éco-certifiés, carrelages grand format, sols acoustiques pour open spaces, résines techniques pour laboratoires et terrasses antidérapantes.</p>
+              <h3>Sols résistants aux saisons normandes</h3>
+              <p>Parquets massifs ou contrecollés, carrelages grand format, sols souples acoustiques, résines techniques pour locaux professionnels et terrasses extérieures antidérapantes.</p>
             </div>
           </div>
           <!-- end tab05 -->
@@ -472,61 +472,27 @@
   <!-- end container -->
 </section>
 <!-- end content-section -->
-<section class="content-section" id="programmes-premium" data-background="#f7f6f1">
-  <div class="container">
-    <div class="row align-items-center">
-      <div class="col-lg-5">
-        <div class="section-title text-left">
-          <h6>PROGRAMMES PREMIUM</h6>
-          <h2>Des offres clés en main pour sécuriser votre patrimoine</h2>
-        </div>
-      </div>
-      <div class="col-lg-7">
-        <p>Nos programmes intègrent conception, travaux et maintenance pour garantir un retour sur investissement mesurable. Ils s’adressent aux entreprises, syndics, bailleurs et propriétaires exigeants.</p>
-      </div>
-      <div class="col-lg-4 col-md-6">
-        <div class="service-card">
-          <h3>Punctual Renewal</h3>
-          <p>Remise à niveau rapide d’espaces critiques : accueil, salles de réunion, appartements témoins. Intervention nocturne ou week-end, planning serré et réception express.</p>
-        </div>
-      </div>
-      <div class="col-lg-4 col-md-6">
-        <div class="service-card">
-          <h3>Complete Renewal</h3>
-          <p>Rénovation globale d’immeubles, maisons ou plateaux tertiaires. Conception architecturale, gestion administrative, suivi BIM et coordination de tous les corps d’état.</p>
-        </div>
-      </div>
-      <div class="col-lg-4 col-md-6">
-        <div class="service-card">
-          <h3>Maintenance 360°</h3>
-          <p>Contrats préventifs et réactifs : CVC, plomberie, électricité, espaces verts, nettoyage technique et assistance aux occupants avec reporting mensuel.</p>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
-<!-- end content-section -->
 <section class="content-section">
   <div class="container">
     <div class="row no-gutters">
       <div class="col-12">
         <div class="section-title text-left">
-          <h6>NORMANDIE & ÎLE-DE-FRANCE</h6>
-          <h2>Secteurs accompagnés</h2>
+          <h6>PARTOUT EN NORMANDIE</h6>
+          <h2>Nous intervenons pour</h2>
         </div>
         <!-- end section-title -->
       </div>
       <!-- end col-12 -->
-      <div class="col-lg-4 col-md-6"> <a href="projects.html" class="sector-box"> <span>Sièges sociaux & coworkings</span> <i class="lni lni-arrow-right"></i> </a> </div>
-      <!-- end col-4 -->
-
       <div class="col-lg-4 col-md-6"> <a href="projects.html" class="sector-box"> <span>Résidences principales & secondaires</span> <i class="lni lni-arrow-right"></i> </a> </div>
       <!-- end col-4 -->
 
       <div class="col-lg-4 col-md-6"> <a href="projects.html" class="sector-box"> <span>Maisons à colombages & patrimoine</span> <i class="lni lni-arrow-right"></i> </a> </div>
       <!-- end col-4 -->
 
-      <div class="col-lg-4 col-md-6"> <a href="projects.html" class="sector-box"> <span>Hôtels, cliniques & établissements recevant du public</span> <i class="lni lni-arrow-right"></i> </a> </div>
+      <div class="col-lg-4 col-md-6"> <a href="projects.html" class="sector-box"> <span>Bureaux, commerces & coworkings</span> <i class="lni lni-arrow-right"></i> </a> </div>
+      <!-- end col-4 -->
+
+      <div class="col-lg-4 col-md-6"> <a href="projects.html" class="sector-box"> <span>Hôtels, gîtes & locations saisonnières</span> <i class="lni lni-arrow-right"></i> </a> </div>
       <!-- end col-4 -->
 
       <div class="col-lg-4 col-md-6"> <a href="projects.html" class="sector-box"> <span>Bâtiments publics & collectivités</span> <i class="lni lni-arrow-right"></i> </a> </div>
@@ -545,11 +511,11 @@
     <div class="row">
       <div class="col-12">
         <figure class="logo"> <img src="images/logo.png" alt="RenoGo"> </figure>
-        <h2>Confiez votre projet à <b>RenoGo</b> et gagnez en confort & performance</h2>
-        <a href="contact.html" class="button">RÉSERVER UNE VISITE CONSEIL <i class="lni lni-arrow-right"></i></a>
+        <h2>Confiez votre projet à <b>RenoGo</b> et vivez la sérénité normande</h2>
+        <a href="contact.html" class="button">OBTENIR UN RENDEZ-VOUS <i class="lni lni-arrow-right"></i></a>
         <div class="sales-representive">
           <figure> <img src="images/author01.jpg" alt="Conseiller RenoGo"> </figure>
-          Conseiller projets France <b>+33 (0)1 86 90 12 45</b> appel gratuit </div>
+          Conseillère dédiée Normandie <b>+33 (0)1 86 90 12 45</b> appel gratuit ! </div>
         <!-- end sales-representive -->
       </div>
       <!-- end col-12  -->
@@ -574,7 +540,7 @@
       <!-- end col-6 -->
       <div class="col-lg-6">
         <h6 class="widget-title">RESTONS EN CONTACT</h6>
-        <p>Recevez nos conseils travaux, guides énergie et offres exclusives pour vos sites en Normandie & Île-de-France.</p>
+        <p>Recevez nos conseils saisonniers et nos offres exclusives pour vos projets en Normandie.</p>
         <form>
           <input type="email" placeholder="Votre e-mail">
           <input type="submit" value="S'INSCRIRE">
@@ -582,7 +548,7 @@
       </div>
       <!-- end col-6 -->
       <div class="col-12">
-        <div class="footer-bottom"> <span>© 2024 RenoGo | Rénovation, entretien et maintenance en Normandie &amp; Île-de-France</span>
+        <div class="footer-bottom"> <span>© 2024 RenoGo | Rénovation, entretien et maintenance en Normandie</span>
           <ul>
             <li><a href="#">Facebook</a></li>
             <li><a href="#">Instagram</a></li>


### PR DESCRIPTION
## Summary
- revert merge #26 to restore the previous homepage copy and metadata
- revert merge #25 so that page content and SEO tags match the prior Saturday version across the site

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daa2ff6b1c832eaf85267e7fcb39c1