### PR TITLE
Revise RenoGo website copy for strategic SEO messaging

### DIFF
--- a/about-company.html
+++ b/about-company.html
@@ -6,8 +6,8 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <!-- Primary SEO -->
-  <title>RenoGo • Rénovation intérieure & amélioration de l’habitat en France</title>
-  <meta name="description" content="RenoGo rénove et transforme appartements et maisons : cuisines, salles de bain, isolation, électricité, peinture. Devis rapide, travaux qualitatifs, livrés à temps.">
+  <title>À propos de RenoGo • Contractant rénovation & maintenance Normandie – Île-de-France</title>
+  <meta name="description" content="Découvrez la vision RenoGo : ingénierie de projets, rénovation énergétique, aménagement d’espaces et maintenance immobilière pour particuliers, PME et bailleurs en Normandie et Île-de-France.">
   <link rel="canonical" href="https://www.renogo.fr/">
 
   <!-- Indexing -->
@@ -29,8 +29,8 @@
   <meta property="og:locale" content="fr_FR">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="RenoGo">
-  <meta property="og:title" content="RenoGo • Rénovation intérieure & amélioration de l’habitat">
-  <meta property="og:description" content="Cuisine, salle de bain, peinture, isolation et plus. Devis rapide, travaux maîtrisés.">
+  <meta property="og:title" content="À propos de RenoGo • Contractant rénovation Normandie & Île-de-France">
+  <meta property="og:description" content="Pilotage de travaux, innovation durable et maintenance immobilière pour logements, bureaux et copropriétés.">
   <meta property="og:url" content="https://www.renogo.fr/">
   <meta property="og:image" content="https://www.renogo.fr/assets/og/renogo-cover.jpg">
   <meta property="og:image:width" content="1200">
@@ -39,8 +39,8 @@
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@renogo">
-  <meta name="twitter:title" content="RenoGo • Rénovation intérieure & amélioration de l’habitat">
-  <meta name="twitter:description" content="Rénovation d’appartements et maisons en France. Devis rapide, délais tenus.">
+  <meta name="twitter:title" content="À propos de RenoGo • Contractant rénovation Normandie & Île-de-France">
+  <meta name="twitter:description" content="Expertise chantier, efficacité énergétique et services multitechniques pour particuliers et professionnels.">
   <meta name="twitter:image" content="https://www.renogo.fr/assets/og/renogo-cover.jpg">
 
   <!-- Organization -->
@@ -75,7 +75,7 @@
     "url": "https://www.renogo.fr/",
     "logo": "https://www.renogo.fr/assets/logo/renogo-logo.svg",
     "image": "https://www.renogo.fr/assets/og/renogo-cover.jpg",
-    "description": "Rénovation intérieure d’appartements et maisons : cuisines, salles de bain, isolation, électricité, peinture.",
+    "description": "Rénovation globale, aménagement d’espaces et maintenance immobilière pour maisons, bureaux et copropriétés.",
     "telephone": "+33-1-23-45-67-89",
     "areaServed": "FR",
     "priceRange": "€€",
@@ -235,7 +235,7 @@
 <header class="page-header">
   <div class="container">
     <h1>À PROPOS</h1>
-          <h6>Une équipe proche des territoires normands, dédiée aux intérieurs vivants et aux extérieurs verdoyants.</h6>
+          <h6>Contractant général basé à Paris, engagé sur les chantiers de Normandie et d’Île-de-France.</h6>
           <ul>
                 <li><a href="#">ACCUEIL</a></li>
                 <li>À PROPOS</li>
@@ -249,21 +249,21 @@
     <div class="row">
                 <div class="col-12">
                          <div class="section-title text-left">
-          <h6>NOTRE HISTOIRE</h6>
-          <h2>RenoGo, passerelle entre Paris et la Normandie</h2>
+          <h6>NOTRE ADN</h6>
+          <h2>De grands projets internationaux aux rénovations locales maîtrisées</h2>
         </div>
         <!-- end section-title -->
                 </div>
                 <!-- end col-12 -->
                 <div class="col-md-7">
                 <figure><img src="images/salon.jpg" alt="Équipe RenoGo en intervention"></figure>
-                        <p>Tout est parti d'un appartement parisien transformé pour un couple originaire du Calvados. Touchés par notre sens du détail et notre écoute, ils ont soufflé à leurs proches l'idée de nous confier leurs résidences secondaires. De fil en aiguille, RenoGo a suivi la route des falaises d'Étretat aux marais du Cotentin pour devenir la référence de la rénovation clé en main en Normandie.</p>
-                        <p>À chaque chantier, nous conjugons savoir-faire artisanal et technologies intelligentes : éclairage connecté à Honfleur, isolation biosourcée à Caen, jardins comestibles à Deauville… Notre promesse reste la même : révéler le potentiel des maisons et bureaux normands en respectant leur âme, leurs matériaux et les cycles naturels du territoire.</p>
+                        <p>Après treize années à conduire des projets de construction et d’infrastructures télécoms sur trois continents, notre fondateur a imaginé RenoGo comme un hub opérationnel dédié aux propriétaires franciliens et normands. Nous importons les meilleures pratiques de gestion de projet — planification rigoureuse, contrôle qualité, suivi digital — pour livrer des chantiers sans imprévus.</p>
+                        <p>De la résidence secondaire à Trouville aux bureaux d’une PME à Saint-Quentin-en-Yvelines, nous sécurisons chaque étape : audit énergétique, modélisation des espaces, coordination des lots techniques, réception et maintenance préventive. Notre promesse : révéler le potentiel de vos biens en respectant leur identité architecturale et vos objectifs économiques.</p>
                 </div>
                 <!-- end col-7 -->
                 <div class="col-md-5">
                 <figure><img src="images/jardin-a-propos.jpg" alt="Services RenoGo"></figure>
-                        <p>Implantés à Paris, nous avons constitué un réseau d'artisans locaux certifiés RGE, paysagistes, électriciens et peintres capables d'intervenir rapidement dans chaque département normand. Cette alliance nous permet d'assurer la même qualité RenoGo, de Granville à Dieppe.</p>
+                        <p>Basés à Paris et présents sur le terrain en Normandie, nous nous appuyons sur un réseau d’artisans RGE, de bureaux d’études et de partenaires maintenance sélectionnés pour leur fiabilité. Cette équipe agile nous permet de déployer la même signature RenoGo à Caen, Rouen, Évreux, Cherbourg ou Versailles.</p>
                 </div>
                 <!-- end col-5 -->
           </div>
@@ -277,8 +277,8 @@
     <div class="row">
       <div class="col-lg-3 col-md-6">
         <div class="counter-box"> <span class="odometer" data-count="98" data-status="yes">0</span> <span class="value">%</span>
-          <h6>Clients enchantés</h6>
-          <p>Satisfaction mesurée après chaque livraison de chantier sur Caen, Rouen et Le Havre.</p>
+          <h6>Taux de recommandations</h6>
+          <p>Nos clients particuliers, investisseurs et PME nous recommandent après chaque livraison suivie et contrôlée.</p>
         </div>
         <!-- end counter-box -->
       </div>
@@ -286,23 +286,23 @@
       <div class="col-lg-3 col-md-6">
         <div class="counter-box"> <span class="odometer" data-count="365" data-status="yes">0</span> <span class="value">j</span>
           <h6>Assistance continue</h6>
-          <p>Maintenance préventive et corrective disponible toute l'année pour vos bâtiments.</p>
+          <p>Hotline et visites programmées 365 jours par an pour sécuriser vos résidences, bureaux et commerces.</p>
         </div>
         <!-- end counter-box -->
       </div>
       <!-- end col-3 -->
       <div class="col-lg-3 col-md-6">
         <div class="counter-box"> <span class="odometer" data-count="450" data-status="yes">0</span> <span class="value">m²</span>
-          <h6>Espaces rénovés chaque mois</h6>
-          <p>De la peinture intérieure aux sols sur mesure, nous optimisons vos surfaces.</p>
+          <h6>Mètres carrés optimisés</h6>
+          <p>450 m² rénovés ou réaménagés chaque mois : isolation, second œuvre, space-planning et finitions premium.</p>
         </div>
         <!-- end counter-box -->
       </div>
       <!-- end col-3 -->
       <div class="col-lg-3 col-md-6">
         <div class="counter-box"> <span class="odometer" data-count="120" data-status="yes">0</span> <span class="value">+</span>
-          <h6>Projets paysagers</h6>
-          <p>Potagers, terrasses bois et jardins zen qui prolongent la vie dehors même en bord de mer.</p>
+          <h6>Projets multisites</h6>
+          <p>Résidences, copropriétés et actifs tertiaires supervisés avec la même exigence du Cotentin aux Hauts-de-Seine.</p>
         </div>
         <!-- end counter-box -->
       </div>
@@ -319,13 +319,13 @@
                 <div class="col-lg-7">
         <div class="section-title text-left">
           <h6>MÉTHODE RENOGO</h6>
-          <h2>Notre accompagnement en trois engagements</h2>
+          <h2>Un pilotage de chantier pensé pour vos usages</h2>
         </div>
         <!-- end section-title -->
       </div>
       <!-- end col-7 -->
       <div class="col-lg-5">
-        <p>Notre portfolio reflète trente ans d'expérience cumulée, des investissements réguliers dans les innovations vertes et une culture du service qui place votre confort au cœur du projet.</p>
+        <p>Notre approche associe expertise de terrain, outils digitaux et engagement écologique pour garantir des rénovations fiables, performantes et simples à vivre pour vos équipes comme pour votre famille.</p>
       </div>
       <!-- end col-5 -->
                 <div class="col-lg-4">
@@ -334,8 +334,8 @@
                         <div class="content">
                                 <span>01.</span>
                         <figure class="icon"><img src="images/icon01.png" alt="Icône écoute"></figure>
-                                <h6>Diagnostic sur site</h6>
-                                <p>Visite technique, thermographie et relevés lumière pour imaginer la solution la plus adaptée à votre bien normand.</p>
+                                <h6>Diagnostic & audit</h6>
+                                <p>Visite technique, relevés BIM et audit énergétique pour cadrer objectifs, budget et planning.</p>
                         </div>
                                 <!-- end content -->
                         </div>
@@ -348,8 +348,8 @@
                         <div class="content">
                                 <span>02.</span>
                         <figure class="icon"><img src="images/icon02.png" alt="Icône organisation"></figure>
-                                <h6>Planification harmonieuse</h6>
-                                <p>Coordination des corps de métiers, sélection de matériaux durables et suivi numérique accessible en temps réel.</p>
+                                <h6>Planification collaborative</h6>
+                                <p>Coordination des corps d’état, matériaux certifiés et plateforme de suivi accessible 24/7.</p>
                         </div>
                                 <!-- end content -->
                         </div>
@@ -363,7 +363,7 @@
                                 <span>03.</span>
                         <figure class="icon"><img src="images/icon03.png" alt="Icône partenariat"></figure>
                                 <h6>Suivi durable</h6>
-                                <p>Contrôles annuels, conseils d'entretien saisonniers et hotline pour anticiper chaque besoin.</p>
+                                <p>Contrôles qualité, DOE numérique, maintenance préventive et hotline pour anticiper chaque besoin.</p>
                         </div>
                                 <!-- end content -->
                         </div>
@@ -415,8 +415,8 @@
       <div class="col-12">
         <div class="video-box"> <a href="videos/video01.mp4" data-fancybox data-width="640" data-height="360" class="play-btn"><i class="lni lni-play"></i></a>
           <h6>VISITE D'UN CHANTIER</h6>
-          <h2>Découvrez comment RenoGo redonne vie aux demeures normandes</h2>
-          <p>Plongez dans un projet complet mené à Cabourg : isolation acoustique, peinture aux pigments naturels, terrasse bois avec éclairage connecté et serre urbaine pour aromatiques.</p>
+          <h2>Suivez la transformation d’un immeuble mixte à Rouen</h2>
+          <p>Découvrez comment nous avons rénové des plateaux bureaux et trois appartements locatifs : performance énergétique, flex-office, finitions premium et jardin partagé sur toit.</p>
         </div>
         <!-- end video-box -->
       </div>
@@ -427,9 +427,9 @@
       <div class="col-lg-8">
         <div class="accordion" id="accordion" role="tablist">
             <div class="card">
-              <div class="card-header" role="tab" id="headingOne"> <a data-toggle="collapse" href="#collapseOne" aria-expanded="true" aria-controls="collapseOne"> Quels services RenoGo propose-t-elle en Normandie ? <i class="lni lni-arrow-right"></i></a> </div>
+              <div class="card-header" role="tab" id="headingOne"> <a data-toggle="collapse" href="#collapseOne" aria-expanded="true" aria-controls="collapseOne"> Quels services RenoGo propose-t-elle en Normandie et Île-de-France ? <i class="lni lni-arrow-right"></i></a> </div>
               <div id="collapseOne" class="collapse show" role="tabpanel" aria-labelledby="headingOne" data-parent="#accordion">
-                <div class="card-body"> Nous intervenons sur le jardinage et l'aménagement paysager, les travaux d'électricité et de domotique, la peinture intérieure et extérieure, les cloisons sèches et l'isolation ainsi que la pose de revêtements de sol adaptés aux climats normands.</div>
+                <div class="card-body"> Nous pilotons des rénovations complètes, travaux d’efficacité énergétique, aménagements intérieurs, modernisation de bureaux, création d’espaces extérieurs et contrats de maintenance multitechnique pour copropriétés, bailleurs et PME.</div>
                 <!-- end card-body -->
               </div>
               <!-- end collapse -->
@@ -438,7 +438,7 @@
             <div class="card">
               <div class="card-header" role="tab" id="headingTwo"> <a class="collapsed" data-toggle="collapse" href="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo"> Comment garantissez-vous la qualité des chantiers ? <i class="lni lni-arrow-right"></i></a> </div>
               <div id="collapseTwo" class="collapse" role="tabpanel" aria-labelledby="headingTwo" data-parent="#accordion">
-                <div class="card-body"> Chaque projet est suivi par un chef de chantier RenoGo, épaulé par des artisans certifiés RGE et Qualifelec. Nous utilisons un carnet de chantier numérique partagé avec vous pour valider chaque étape, du choix des matériaux à la réception.</div>
+                <div class="card-body"> Chaque projet est suivi par un chef de projet dédié, épaulé par des artisans certifiés RGE, Qualifelec et Qualibat. Planning prévisionnel, point hebdomadaire et carnet de chantier numérique garantissent transparence et maîtrise des coûts.</div>
                 <!-- end card-body -->
               </div>
               <!-- end collapse -->
@@ -447,7 +447,7 @@
             <div class="card">
               <div class="card-header" role="tab" id="headingThree"> <a class="collapsed" data-toggle="collapse" href="#collapseThree" aria-expanded="false" aria-controls="collapseThree"> Intervenez-vous sur les résidences secondaires ? <i class="lni lni-arrow-right"></i></a> </div>
               <div id="collapseThree" class="collapse" role="tabpanel" aria-labelledby="headingThree" data-parent="#accordion">
-                <div class="card-body"> Oui, c'est même notre spécialité. Nous gérons les clés, organisons les rendez-vous de chantier avec vos voisins et pouvons équiper votre maison de systèmes intelligents pour surveiller l'humidité, le chauffage et l'arrosage à distance.</div>
+                <div class="card-body"> Oui, c’est même notre spécialité. Nous gérons les clés, organisons les réunions de chantier à distance et installons des solutions smart home pour contrôler chauffage, humidité, sécurité et arrosage.</div>
                 <!-- end card-body -->
               </div>
               <!-- end collapse -->
@@ -456,7 +456,7 @@
             <div class="card">
               <div class="card-header" role="tab" id="headingFour"> <a class="collapsed" data-toggle="collapse" href="#collapseFour" aria-expanded="false" aria-controls="collapseFour"> Proposez-vous des contrats de maintenance ? <i class="lni lni-arrow-right"></i></a> </div>
               <div id="collapseFour" class="collapse" role="tabpanel" aria-labelledby="headingFour" data-parent="#accordion">
-                <div class="card-body"> Nous proposons des formules préventives et correctives pour les copropriétés, bureaux et établissements recevant du public. Jardins, éclairages, systèmes domotiques et contrôles réglementaires : RenoGo s'occupe de tout pour sécuriser vos installations.</div>
+                <div class="card-body"> Nous proposons des formules préventives et correctives pour copropriétés, bureaux, commerces et hôtels. Jardin, éclairage, CVC, SSI, domotique et contrôles réglementaires : RenoGo s’occupe de tout pour sécuriser vos actifs.</div>
                 <!-- end card-body -->
               </div>
               <!-- end collapse -->
@@ -469,8 +469,8 @@
                 <div class="col-lg-4">
                 <div class="info-box-dark">
                         <h6>BOÎTE À IDÉES</h6>
-                        <p>Besoin d'inspiration pour transformer votre longère ou votre open-space ? Nos conseillers viennent sur place pour imaginer avec vous un parcours travaux optimisé et respectueux de l'identité normande.</p>
-                        <p>Demandez notre guide gratuit « Habiter la Normandie autrement » pour découvrir des réalisations à Bayeux, Cherbourg et Alençon, ainsi que nos astuces entretien selon les saisons.</p>
+                        <p>Besoin d’inspiration pour réinventer votre longère, votre duplex parisien ou votre open-space ? Nos conseillers co-construisent un plan travaux sur mesure mêlant design, énergie et maintenance.</p>
+                        <p>Téléchargez notre guide gratuit « Rénover & exploiter son patrimoine en Normandie et Île-de-France » pour découvrir études de cas, check-lists réglementaires et calendrier d’entretien.</p>
                         </div>
                         <!-- end info-box-dark -->
                 </div>
@@ -486,9 +486,9 @@
                         <div class="row">
                                 <div class="col-lg-8">
                                 <div class="cta-box-yellow">
-                                        <h4>Le premier ouvrage RenoGo, c'est la confiance</h4>
-                                        <p>Avant chaque chantier, nous prenons le temps de visiter votre lieu de vie, de comprendre vos habitudes et d'écrire un scénario travaux sur mesure. C'est ainsi que nous créons des intérieurs chaleureux et des extérieurs accueillants, du bocage ornais aux falaises de la Côte d'Albâtre.</p>
-                                        <a href="contact.html" class="button">OBTENIR UN DEVIS</a>
+                                        <h4>Le premier ouvrage RenoGo, c’est la confiance</h4>
+                                        <p>Nous auditons votre patrimoine, construisons un phasage sur mesure et sécurisons chaque lot avec des artisans fiables. Résultat : des intérieurs chaleureux, des extérieurs accueillants et des actifs durables.</p>
+                                        <a href="contact.html" class="button">OBTENIR UN DIAGNOSTIC</a>
                                         </div>
                                         <!-- end cta-box-yellow -->
                                 </div>
@@ -505,8 +505,8 @@
       <div class="col-12">
 
           <figure class="logo"> <img src="images/logo.png" alt="Logo RenoGo"></figure>
-          <h2>Vivez <b>mieux</b> et <b>plus sereinement</b> en Normandie</h2>
-          <a href="contact.html" class="button">DEMANDER UNE CONSULTATION <i class="lni lni-arrow-right"></i></a>
+          <h2>Valorisez <b>votre patrimoine</b> en Normandie & Île-de-France</h2>
+          <a href="contact.html" class="button">PLANIFIER UN RENDEZ-VOUS <i class="lni lni-arrow-right"></i></a>
                   <div class="sales-representive">
                         <figure>
                                 <img src="images/author01.jpg" alt="Conseiller RenoGo">
@@ -548,7 +548,7 @@
       <!-- end col-6 -->
                 <div class="col-12">
                         <div class="footer-bottom">
-                                <span>© 2024 RenoGo. Tous droits réservés.</span>
+                                <span>© 2025 RenoGo • Rénovation & maintenance immobilière – Normandie & Île-de-France.</span>
                                 <ul>
                                 <li><a href="#">Facebook</a></li>
                                 <li><a href="#">Instagram</a></li>

--- a/contact.html
+++ b/contact.html
@@ -6,8 +6,8 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <!-- Primary SEO -->
-  <title>RenoGo • Rénovation intérieure & amélioration de l’habitat en France</title>
-  <meta name="description" content="RenoGo rénove et transforme appartements et maisons : cuisines, salles de bain, isolation, électricité, peinture. Devis rapide, travaux qualitatifs, livrés à temps.">
+  <title>Contact RenoGo • Devis rénovation & maintenance immobilière Normandie – Île-de-France</title>
+  <meta name="description" content="Contactez RenoGo pour vos projets de rénovation, d’efficacité énergétique, d’aménagement intérieur-extérieur et de maintenance immobilière en Normandie et Île-de-France.">
   <link rel="canonical" href="https://www.renogo.fr/">
 
   <!-- Indexing -->
@@ -29,8 +29,8 @@
   <meta property="og:locale" content="fr_FR">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="RenoGo">
-  <meta property="og:title" content="RenoGo • Rénovation intérieure & amélioration de l’habitat">
-  <meta property="og:description" content="Cuisine, salle de bain, peinture, isolation et plus. Devis rapide, travaux maîtrisés.">
+  <meta property="og:title" content="Contact RenoGo • Rénovation & maintenance immobilière">
+  <meta property="og:description" content="Demandez un audit ou un devis : rénovations globales, travaux énergétiques, aménagements de bureaux et contrats de maintenance.">
   <meta property="og:url" content="https://www.renogo.fr/">
   <meta property="og:image" content="https://www.renogo.fr/assets/og/renogo-cover.jpg">
   <meta property="og:image:width" content="1200">
@@ -39,8 +39,8 @@
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@renogo">
-  <meta name="twitter:title" content="RenoGo • Rénovation intérieure & amélioration de l’habitat">
-  <meta name="twitter:description" content="Rénovation d’appartements et maisons en France. Devis rapide, délais tenus.">
+  <meta name="twitter:title" content="Contact RenoGo • Rénovation & maintenance immobilière">
+  <meta name="twitter:description" content="Prenez rendez-vous avec RenoGo pour vos projets en Normandie et Île-de-France : rénovation, énergie, smart building, paysage.">
   <meta name="twitter:image" content="https://www.renogo.fr/assets/og/renogo-cover.jpg">
 
   <!-- Organization -->
@@ -75,7 +75,7 @@
     "url": "https://www.renogo.fr/",
     "logo": "https://www.renogo.fr/assets/logo/renogo-logo.svg",
     "image": "https://www.renogo.fr/assets/og/renogo-cover.jpg",
-    "description": "Rénovation intérieure d’appartements et maisons : cuisines, salles de bain, isolation, électricité, peinture.",
+    "description": "Rénovation globale, efficacité énergétique, design d’espace et maintenance immobilière.",
     "telephone": "+33-1-23-45-67-89",
     "areaServed": "FR",
     "priceRange": "€€",
@@ -144,10 +144,10 @@
 
     <div class="hide-mobile">
       <p>
-        RenoGo accompagne vos projets de rénovation et d’entretien en Normandie :
-        <u>électricité & éclairage</u>, <u>peinture & sols</u>, <u>cloisons & isolation</u>,
-        <u>jardinage & aménagement paysager</u>, ainsi que <u>domotique / maison intelligente</u>.
-        Des chantiers propres, des délais tenus, un suivi de proximité.
+        RenoGo coordonne vos projets de rénovation, d’aménagement et de maintenance immobilière en Normandie et en Île-de-France :
+        <u>rénovation énergétique</u>, <u>second œuvre</u>, <u>domotique & smart building</u>,
+        <u>aménagement paysager</u> et <u>services multitechniques</u>.
+        Un pilotage unique, des artisans qualifiés, des livraisons sans surprise.
       </p>
 
       <figure class="gallery">
@@ -235,7 +235,7 @@
 <header class="page-header">
   <div class="container">
     <h1>Contactez</h1>
-          <h6>Vos projets prennent vie entre Paris et la Normandie, orchestrés par une équipe qui conjugue innovation, précision et amour du bâti.</h6>
+          <h6>Parlez-nous de vos projets de rénovation, d’efficacité énergétique ou de maintenance immobilière en Normandie et Île-de-France.</h6>
           <ul>
                 <li><a href="index.html">Accueil</a></li>
                 <li>Contact</li>
@@ -251,7 +251,7 @@
         <div class="contact-box">
                         <figure><img src="images/icon-global.png" alt="Bureaux RenoGo"></figure>
           <h6>Maison RenoGo</h6>
-                <p>59, rue de Ponthieu, Bureau 326<br>75008 Paris</p>
+                <p>59, rue de Ponthieu, Bureau 326<br>75008 Paris<br>Interventions Normandie & Île-de-France</p>
 
         </div>
         <!-- end contact-box -->
@@ -261,7 +261,7 @@
         <div class="contact-box">
                         <figure><img src="images/icon-phone.png" alt="Téléphone RenoGo"></figure>
           <h6>Appelez-nous</h6>
-           <p>+33 (0)1 84 60 22 90<br>Service client & astreinte chantier</p>
+           <p>+33 (0)1 84 60 22 90<br>Service client, devis & astreinte chantier</p>
         </div>
         <!-- end contact-box -->
       </div>
@@ -287,8 +287,8 @@
       <div class="col-lg-6">
           <div class="section-title text-left">
           <h6>Notre promesse</h6>
-          <h2>Une équipe qui connaît<br>
-            chaque saison normande</h2>
+          <h2>Une équipe qui pilote vos chantiers<br>
+            en Normandie et Île-de-France</h2>
         </div>
         <!-- end section-title -->
       </div>
@@ -307,7 +307,7 @@
                  <!-- end form-group -->
                         <div class="form-group">
                         <span>Projet</span>
-                                <input type="text" placeholder="Rénovation, entretien, jardin..."></input>
+                                <input type="text" placeholder="Rénovation globale, énergie, fit-out..."></input>
                  </div>
                  <!-- end form-group -->
                         <div class="form-group">
@@ -339,14 +339,14 @@
       <div class="col-12">
 
           <figure class="logo"> <img src="images/logo.png" alt="RenoGo"> </figure>
-          <h2>Construisons une Normandie <b>durable</b> et <b>inspirante</b></h2>
-          <a href="#" class="button">OBTENIR UN DEVIS <i class="lni lni-arrow-right"></i></a>
+          <h2>Bâtissons ensemble des espaces <b>performants</b> et <b>durables</b></h2>
+          <a href="contact.html" class="button">RÉSERVER UN AUDIT <i class="lni lni-arrow-right"></i></a>
                   <div class="sales-representive">
                         <figure>
                                 <img src="images/author01.jpg" alt="Conseiller RenoGo">
-                          </figure>Votre conseiller dédié
+                          </figure>Votre conseiller Normandie & Île-de-France
 
-                          <b>+33 (0)1 84 60 22 90</b> appel gratuit depuis la France
+                          <b>+33 (0)1 84 60 22 90</b> — appel gratuit depuis la France
                   </div>
                   <!-- end sales-representive -->
                 </div>
@@ -382,7 +382,7 @@
       <!-- end col-6 -->
                 <div class="col-12">
                         <div class="footer-bottom">
-                                <span>© 2024 RenoGo | Rénovation, Maintenance & Paysage en Normandie</span>
+                                <span>© 2025 RenoGo • Rénovation & maintenance immobilière – Normandie & Île-de-France</span>
                                 <ul>
                                 <li><a href="#">Facebook</a></li>
                                 <li><a href="#">Instagram</a></li>

--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <!-- Primary SEO -->
-  <title>RenoGo • Rénovation intérieure & amélioration de l’habitat en France</title>
-  <meta name="description" content="RenoGo rénove et transforme appartements et maisons : cuisines, salles de bain, isolation, électricité, peinture. Devis rapide, travaux qualitatifs, livrés à temps.">
+  <title>RenoGo • Rénovation globale & maintenance immobilière en Normandie et Île-de-France</title>
+  <meta name="description" content="RenoGo pilote vos travaux de rénovation, d’efficacité énergétique et d’aménagement intérieur-extérieur en Normandie et Île-de-France. Solutions clés en main pour particuliers, professionnels et bailleurs.">
   <link rel="canonical" href="https://www.renogo.fr/">
 
   <!-- Indexing -->
@@ -29,8 +29,8 @@
   <meta property="og:locale" content="fr_FR">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="RenoGo">
-  <meta property="og:title" content="RenoGo • Rénovation intérieure & amélioration de l’habitat">
-  <meta property="og:description" content="Cuisine, salle de bain, peinture, isolation et plus. Devis rapide, travaux maîtrisés.">
+  <meta property="og:title" content="RenoGo • Rénovation globale & maintenance immobilière">
+  <meta property="og:description" content="Rénovation énergétique, aménagement d’intérieurs, modernisation de bureaux et copropriétés en Normandie et Île-de-France.">
   <meta property="og:url" content="https://www.renogo.fr/">
   <meta property="og:image" content="https://www.renogo.fr/assets/og/renogo-cover.jpg">
   <meta property="og:image:width" content="1200">
@@ -39,8 +39,8 @@
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@renogo">
-  <meta name="twitter:title" content="RenoGo • Rénovation intérieure & amélioration de l’habitat">
-  <meta name="twitter:description" content="Rénovation d’appartements et maisons en France. Devis rapide, délais tenus.">
+  <meta name="twitter:title" content="RenoGo • Rénovation globale & maintenance immobilière">
+  <meta name="twitter:description" content="Contractant rénovation, efficacité énergétique, aménagement de bureaux et maisons à Caen, Rouen, Paris.">
   <meta name="twitter:image" content="https://www.renogo.fr/assets/og/renogo-cover.jpg">
 
   <!-- Organization -->
@@ -75,7 +75,7 @@
     "url": "https://www.renogo.fr/",
     "logo": "https://www.renogo.fr/assets/logo/renogo-logo.svg",
     "image": "https://www.renogo.fr/assets/og/renogo-cover.jpg",
-    "description": "Rénovation intérieure d’appartements et maisons : cuisines, salles de bain, isolation, électricité, peinture.",
+    "description": "Rénovation globale, efficacité énergétique, aménagement d’intérieurs et maintenance immobilière en Normandie et Île-de-France.",
     "telephone": "+33-1-23-45-67-89",
     "areaServed": "FR",
     "priceRange": "€€",
@@ -144,10 +144,10 @@
 
     <div class="hide-mobile">
       <p>
-        RenoGo accompagne vos projets de rénovation et d’entretien en Normandie :
-        <u>électricité & éclairage</u>, <u>peinture & sols</u>, <u>cloisons & isolation</u>,
-        <u>jardinage & aménagement paysager</u>, ainsi que <u>domotique / maison intelligente</u>.
-        Des chantiers propres, des délais tenus, un suivi de proximité.
+        RenoGo coordonne vos projets de rénovation, d’aménagement et de maintenance immobilière en Normandie et en Île-de-France :
+        <u>rénovation énergétique</u>, <u>second œuvre</u>, <u>domotique & smart building</u>,
+        <u>aménagement paysager</u> et <u>services multitechniques</u>.
+        Un pilotage unique, des artisans qualifiés, des livraisons sans surprise.
       </p>
 
       <figure class="gallery">
@@ -240,8 +240,8 @@
         <!-- Slide 1 -->
         <div class="swiper-slide">
           <div class="inner">
-            <h2>Transformez votre <b>maison</b> en Normandie</h2>
-            <p>De la peinture aux jardins paysagers, RenoGo redonne vie à vos espaces intérieurs et extérieurs avec passion et savoir-faire.</p>
+            <h2>Réinventez votre <b>patrimoine immobilier</b></h2>
+            <p>RenoGo pilote vos rénovations complètes en Normandie et Île-de-France : audits, conception, coordination des corps d’état et réception clé en main.</p>
             <a href="services.html">DÉCOUVRIR NOS SERVICES <i class="lni lni-arrow-right"></i></a>
           </div>
         </div>
@@ -250,8 +250,8 @@
         <!-- Slide 2 -->
         <div class="swiper-slide">
           <div class="inner">
-            <h2>Un habitat <b>confortable</b> & connecté</h2>
-            <p>Électricité, éclairage, domotique et isolation : nous modernisons votre logement pour plus de confort, d’efficacité énergétique et de sérénité.</p>
+            <h2>Des espaces <b>efficients</b> & connectés</h2>
+            <p>Ingénierie électrique, domotique, CVC et performance énergétique : nous créons des logements et bureaux responsables qui réduisent vos charges.</p>
             <a href="projects.html">VOIR NOS RÉALISATIONS <i class="lni lni-arrow-right"></i></a>
           </div>
         </div>
@@ -260,8 +260,8 @@
         <!-- Slide 3 -->
         <div class="swiper-slide">
           <div class="inner">
-            <h2>Un cadre de vie <b>harmonieux</b></h2>
-            <p>Jardins soignés, sols élégants, murs impeccables : RenoGo crée des espaces où il fait bon vivre en Normandie.</p>
+            <h2>Un cadre de vie <b>durable</b></h2>
+            <p>Paysagisme, maintenance préventive et finitions haut de gamme : nous entretenons vos résidences, hôtels et copropriétés avec la même exigence.</p>
             <a href="contact.html">DEMANDER UN DEVIS <i class="lni lni-arrow-right"></i></a>
           </div>
         </div>
@@ -300,7 +300,7 @@
         <div class="icon-content">
           <figure><img src="images/icon03.png" alt="Experts RenoGo rénovant un appartement en Normandie"></figure>
           <h3>Rénovation</h3>
-          <small>Du diagnostic des volumes à la remise des clés, nous orchestrons des rénovations inspirées des maisons normandes : matériaux durables, artisans fiables et finitions qui racontent l’histoire de votre foyer.</small>
+          <small>Diagnostic technique, optimisation énergétique, suivi de chantier : nous orchestrons des rénovations globales certifiées RGE pour valoriser votre maison ou votre patrimoine locatif.</small>
           <a href="services.html#tab02">+</a>
         </div>
       </div>
@@ -310,7 +310,7 @@
         <div class="icon-content">
           <figure><img src="images/icon05.png" alt="Aménagement intérieur RenoGo optimisant un espace de vie"></figure>
           <h3>Aménagement</h3>
-          <small>Cuisines conviviales, pièces de vie lumineuses, suites parentales sur mesure : nous imaginons des aménagements fluides qui valorisent chaque mètre carré et améliorent le quotidien de toute la famille.</small>
+          <small>Cuisines ergonomiques, suites parentales, plateaux bureaux modulaires : nos designers créent des aménagements intelligents qui améliorent le confort et la productivité.</small>
           <a href="services.html#tab05">+</a>
         </div>
       </div>
@@ -320,7 +320,7 @@
         <div class="icon-content">
           <figure><img src="images/icon06.png" alt="Réaménagement de locaux professionnels par RenoGo"></figure>
           <h3>Locaux Professionnels</h3>
-          <small>Bureaux, boutiques ou cabinets libéraux : nous scénarisons vos espaces professionnels avec une approche ROI et bien-être, pour accueillir vos équipes et vos clients dans un cadre cohérent avec votre marque.</small>
+          <small>Bureaux, commerces, cabinets et coworkings : nous intégrons ergonomie, sécurité et branding pour offrir des espaces performants alignés sur vos objectifs business.</small>
           <a href="services.html#services-electricite">+</a>
         </div>
       </div>
@@ -335,8 +335,8 @@
       <div class="col-12">
         <div class="section-title">
           <h6>NOTRE HISTOIRE</h6>
-          <h2>Qualité & Passion<br>
-            au service de votre habitat</h2>
+          <h2>Ingénierie, confiance & proximité<br>
+            au service de vos chantiers</h2>
         </div>
         <!-- end section-title --> 
       </div>
@@ -351,14 +351,14 @@
 
       <div class="col-lg-6">
         <div class="side-content">
-          <h5>Une entreprise née de la confiance des familles normandes</h5>
-          <p>Active dans toute la Normandie, RenoGo accompagne les particuliers et entreprises dans leurs projets de rénovation, d’aménagement intérieur et d’entretien. Notre objectif : créer des espaces de vie plus confortables, esthétiques et durables.</p>
+          <h5>De la gestion de projets internationaux à votre rénovation locale</h5>
+          <p>Après plus de 13 ans à piloter des programmes de construction et de télécommunications dans le monde entier, notre fondateur a créé RenoGo pour mettre cette rigueur opérationnelle au service des foyers et entreprises de Normandie et d’Île-de-France.</p>
 
-          <p>De l’<b>isolation thermique</b> à la <b>peinture décorative</b>, en passant par l’<b>installation électrique et la domotique</b>, nos équipes pluridisciplinaires travaillent avec rigueur et passion. Chaque projet est unique, et nous mettons un point d’honneur à respecter vos délais, votre budget et vos attentes.</p>
+          <p>Nous combinons une approche de <b>contractant général</b> et un réseau d’artisans certifiés pour sécuriser vos travaux : audits énergétiques, conception, lots techniques, finitions et maintenance préventive. Chaque projet est scénarisé, planifié et contrôlé pour livrer des espaces performants et inspirants.</p>
 
           <figure><img src="images/minilogo.png" alt="Logo RenoGo"></figure>
           <h6>L’équipe RenoGo</h6>
-          <small>Votre partenaire rénovation & entretien en Normandie</small>
+          <small>Votre partenaire rénovation & maintenance en Normandie et Île-de-France</small>
         </div>
       </div>
       <!-- end col-6 --> 
@@ -376,7 +376,7 @@
         <div class="counter-box"> 
           <span class="odometer" data-count="98" data-status="yes">0</span> <span class="value">%</span>
           <h6>Clients satisfaits</h6>
-          <p>Un taux de satisfaction élevé grâce à notre écoute et notre accompagnement personnalisé.</p>
+          <p>Normandie, Île-de-France et littoral : un accompagnement personnalisé qui fidélise particuliers, bailleurs et PME.</p>
         </div>
       </div>
 
@@ -385,7 +385,7 @@
         <div class="counter-box"> 
           <span class="odometer" data-count="15" data-status="yes">0</span> <span class="value">+</span>
           <h6>Années d’expertise cumulée</h6>
-          <p>Notre équipe réunit plus de 15 ans d’expérience dans des projets menés dans divers secteurs.</p>
+          <p>13 ans de direction de projets internationaux combinés aux savoir-faire locaux de nos partenaires certifiés.</p>
         </div>
       </div>
 
@@ -394,8 +394,8 @@
       <div class="col-lg-3 col-md-6">
         <div class="counter-box"> 
           <span class="odometer" data-count="350" data-status="yes">0</span> <span class="value">+</span>
-          <h6>Clients accompagnés</h6>
-            <p>Un engagement total pour la qualité, l’écoute et le suivi personnalisé de chaque client.</p>
+          <h6>Espaces transformés</h6>
+            <p>Appartements, maisons, bureaux et commerces mis à niveau pour conjuguer confort, efficacité et valeur patrimoniale.</p>
         </div>
       </div>
 
@@ -404,7 +404,7 @@
         <div class="counter-box"> 
           <span class="odometer" data-count="24" data-status="yes">0</span> <span class="value">/7</span>
           <h6>Support réactif</h6>
-          <p>Une équipe disponible pour répondre à vos besoins et assurer le suivi de vos projets.</p>
+          <p>Un point de contact unique, un service desk digital et des visites de contrôle pour sécuriser vos chantiers.</p>
         </div>
       </div>
 
@@ -418,12 +418,12 @@
       <div class="col-lg-7">
         <div class="section-title text-left">
           <h6>PROJETS RÉALISÉS</h6>
-          <h2>Des rénovations réussies<br>
+          <h2>Réhabilitations & fit-out clés en main<br>
             en Normandie et Île-de-France</h2>
         </div>
       </div>
       <div class="col-lg-5">
-        <p>Chaque projet RenoGo est une histoire unique : de la modernisation d’un appartement ancien à Caen, à l’aménagement d’un jardin paysager à Rouen, en passant par la rénovation complète d’une maison familiale à Évreux. Notre passion : transformer vos idées en espaces de vie confortables, durables et élégants.</p>
+        <p>Chaque projet RenoGo est un récit d’ingénierie appliquée : revalorisation d’appartements haussmanniens à Paris, modernisation de bureaux à La Défense, rénovation énergétique d’un pavillon à Caen ou création d’un jardin paysager à Rouen. Notre mission : livrer des espaces confortables, performants et durables.</p>
       </div>
     </div>
   </div>
@@ -632,7 +632,7 @@
             <div class="form-group col-12">
               <div class="info-box">
                 <i class="lni lni-checkmark-circle"></i>
-                Estimation indicative basée sur vos choix. Pour un devis précis en Normandie, <a href="contact.html">contactez RenoGo</a>.
+                Estimation indicative basée sur vos choix. Pour un devis précis en Normandie ou Île-de-France, <a href="contact.html">contactez RenoGo</a>.
               </div>
 
               <div class="price-box">
@@ -919,7 +919,7 @@
       <!-- end col-6 -->
       <div class="col-12">
         <div class="footer-bottom">
-          <span>© 2025 RenoGo • Rénovation intérieure & extérieure — Normandie</span>
+          <span>© 2025 RenoGo • Rénovation & maintenance immobilière – Normandie & Île-de-France</span>
           <ul>
             <li><a href="https://www.facebook.com/" rel="nofollow noopener">Facebook</a></li>
             <li><a href="https://www.instagram.com/" rel="nofollow noopener">Instagram</a></li>

--- a/news.html
+++ b/news.html
@@ -6,8 +6,8 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <!-- Primary SEO -->
-  <title>RenoGo • Rénovation intérieure & amélioration de l’habitat en France</title>
-  <meta name="description" content="RenoGo rénove et transforme appartements et maisons : cuisines, salles de bain, isolation, électricité, peinture. Devis rapide, travaux qualitatifs, livrés à temps.">
+  <title>Actualités RenoGo • Tendances rénovation & conseils immobiliers Normandie – Île-de-France</title>
+  <meta name="description" content="Suivez les actualités RenoGo : conseils rénovation, performance énergétique, aménagements inspirants et maintenance immobilière pour particuliers et professionnels.">
   <link rel="canonical" href="https://www.renogo.fr/">
 
   <!-- Indexing -->
@@ -29,8 +29,8 @@
   <meta property="og:locale" content="fr_FR">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="RenoGo">
-  <meta property="og:title" content="RenoGo • Rénovation intérieure & amélioration de l’habitat">
-  <meta property="og:description" content="Cuisine, salle de bain, peinture, isolation et plus. Devis rapide, travaux maîtrisés.">
+  <meta property="og:title" content="Actualités RenoGo • Rénovation & maintenance immobilière">
+  <meta property="og:description" content="Conseils travaux, retours d’expérience et innovations pour vos chantiers en Normandie et Île-de-France.">
   <meta property="og:url" content="https://www.renogo.fr/">
   <meta property="og:image" content="https://www.renogo.fr/assets/og/renogo-cover.jpg">
   <meta property="og:image:width" content="1200">
@@ -39,8 +39,8 @@
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@renogo">
-  <meta name="twitter:title" content="RenoGo • Rénovation intérieure & amélioration de l’habitat">
-  <meta name="twitter:description" content="Rénovation d’appartements et maisons en France. Devis rapide, délais tenus.">
+  <meta name="twitter:title" content="Actualités RenoGo • Rénovation & maintenance immobilière">
+  <meta name="twitter:description" content="Guides pratiques, innovations et retours de chantiers pour propriétaires, syndics et PME.">
   <meta name="twitter:image" content="https://www.renogo.fr/assets/og/renogo-cover.jpg">
 
   <!-- Organization -->
@@ -75,7 +75,7 @@
     "url": "https://www.renogo.fr/",
     "logo": "https://www.renogo.fr/assets/logo/renogo-logo.svg",
     "image": "https://www.renogo.fr/assets/og/renogo-cover.jpg",
-    "description": "Rénovation intérieure d’appartements et maisons : cuisines, salles de bain, isolation, électricité, peinture.",
+    "description": "Rénovation globale, efficacité énergétique, design d’espace et maintenance immobilière.",
     "telephone": "+33-1-23-45-67-89",
     "areaServed": "FR",
     "priceRange": "€€",
@@ -144,10 +144,10 @@
 
     <div class="hide-mobile">
       <p>
-        RenoGo accompagne vos projets de rénovation et d’entretien en Normandie :
-        <u>électricité & éclairage</u>, <u>peinture & sols</u>, <u>cloisons & isolation</u>,
-        <u>jardinage & aménagement paysager</u>, ainsi que <u>domotique / maison intelligente</u>.
-        Des chantiers propres, des délais tenus, un suivi de proximité.
+        RenoGo coordonne vos projets de rénovation, d’aménagement et de maintenance immobilière en Normandie et en Île-de-France :
+        <u>rénovation énergétique</u>, <u>second œuvre</u>, <u>domotique & smart building</u>,
+        <u>aménagement paysager</u> et <u>services multitechniques</u>.
+        Un pilotage unique, des artisans qualifiés, des livraisons sans surprise.
       </p>
 
       <figure class="gallery">
@@ -233,7 +233,7 @@
 <header class="page-header">
   <div class="container">
     <h1>Actualités</h1>
-          <h6>Histoires vraies de jardins métamorphosés, d'intérieurs réinventés et de maintenance préventive dans toute la Normandie.</h6>
+          <h6>Histoires vraies de rénovations, d’efficacité énergétique et de maintenance immobilière en Normandie et Île-de-France.</h6>
           <ul>
                 <li><a href="index.html">Accueil</a></li>
                 <li>Actualités</li>
@@ -252,7 +252,7 @@
                            </figure>
           <div class="content"> <small>12 mars 2024</small>
             <h3><a href="news-single.html">Un jardin de pluie à Caen : RenoGo sublime la biodiversité urbaine</a></h3>
-            <p>Dans le quartier Venoix, nous avons transformé une cour bétonnée en oasis végétale qui récupère l'eau normande et protège la maison des inondations. L'aménagement paysager et l'arrosage intelligent dialoguent désormais pour un jardin autonome.</p>
+            <p>Dans le quartier Venoix, nous avons transformé une cour bétonnée en oasis végétale qui récupère l'eau de pluie et protège la maison des inondations. Ce jardin de pluie RenoGo inspire déjà des projets similaires à Versailles et Saint-Germain-en-Laye.</p>
             <div class="author"> <img src="images/author01.jpg" alt="Consultante RenoGo"> <span>par <b>Camille, paysagiste RenoGo</b></span> </div>
             <!-- end author -->
                          </div>
@@ -266,7 +266,7 @@
                            </figure>
           <div class="content"> <small>4 mars 2024</small>
             <h3><a href="news-single.html">Rouen : la lumière naturelle prolongée grâce à une domotique maline</a></h3>
-            <p>Pour un cabinet d'avocats rue Jeanne-d'Arc, nos experts en électricité ont installé un pilotage lumineux qui optimise chaque rayon normand. Résultat : 32 % d'économie d'énergie et une ambiance de travail apaisée.</p>
+            <p>Pour un cabinet d'avocats rue Jeanne-d'Arc, nos experts ont installé un pilotage lumineux intelligent synchronisé avec la lumière naturelle. Résultat : 32 % d'économie d'énergie et une ambiance de travail apaisée, duplicable dans les bureaux parisiens.</p>
             <div class="author"> <img src="images/author02.jpg" alt="Chef de projet RenoGo"> <span>par <b>Louis, chef de projet électricité</b></span> </div>
             <!-- end author -->
                          </div>
@@ -280,7 +280,7 @@
                            </figure>
           <div class="content"> <small>27 février 2024</small>
             <h3><a href="news-single.html">Deauville : peinture satinée et atmosphère balnéaire pour une résidence secondaire</a></h3>
-            <p>Entre sable et ciel, nous avons imaginé une palette inspirée des planches. Peintures écologiques, enduits protecteurs et conseils déco ont rendu à cet appartement sa douceur marine.</p>
+            <p>Entre sable et ciel, nous avons imaginé une palette inspirée des planches. Peintures écologiques, enduits protecteurs et conseils déco ont rendu à cet appartement sa douceur marine tout en facilitant la mise en location saisonnière.</p>
             <div class="author"> <img src="images/author03.jpg" alt="Coloriste RenoGo"> <span>par <b>Élise, coloriste RenoGo</b></span> </div>
             <!-- end author -->
                          </div>
@@ -294,7 +294,7 @@
                            </figure>
           <div class="content"> <small>19 février 2024</small>
             <h3><a href="news-single.html">Bayeux : isolation biosourcée pour une longère du XVIIIe siècle</a></h3>
-            <p>La laine de bois et la ouate de cellulose ont enveloppé cette bâtisse pour préserver son patrimoine tout en réduisant les déperditions. Audit énergétique, tests d'étanchéité et suivi sur-mesure ont guidé chaque étape.</p>
+            <p>La laine de bois et la ouate de cellulose ont enveloppé cette bâtisse pour préserver son patrimoine tout en réduisant les déperditions. Audit énergétique, tests d'étanchéité et suivi sur-mesure ont guidé chaque étape et ouvert l’accès aux aides CEE.</p>
             <div class="author"> <img src="images/author04.jpg" alt="Ingénieure RenoGo"> <span>par <b>Manon, ingénieure performance énergétique</b></span> </div>
             <!-- end author -->
                          </div>
@@ -308,7 +308,7 @@
                            </figure>
           <div class="content"> <small>9 février 2024</small>
             <h3><a href="news-single.html">Le Havre : un plan de maintenance préventive pour des bureaux face à la mer</a></h3>
-            <p>Nos techniciens ont sécurisé l'éclairage, les réseaux électriques et la climatisation d'un immeuble tertiaire du quai Frissard. Objectif : zéro interruption de service et un confort durable pour les équipes.</p>
+            <p>Nos techniciens ont sécurisé l'éclairage, les réseaux électriques et la climatisation d'un immeuble tertiaire du quai Frissard, en lien avec le siège parisien. Objectif : zéro interruption de service et un confort durable pour les équipes.</p>
             <div class="author"> <img src="images/author05.jpg" alt="Responsable maintenance RenoGo"> <span>par <b>Arnaud, responsable maintenance</b></span> </div>
             <!-- end author -->
                          </div>
@@ -322,7 +322,7 @@
                            </figure>
           <div class="content"> <small>1 février 2024</small>
             <h3><a href="news-single.html">Honfleur : parquet chêne fumé et dalle minérale pour un commerce d'art</a></h3>
-            <p>Pour accueillir les artistes locaux, nous avons mixé parquet chêne fumé et dalles minérales résistantes. La pose à bâtons rompus capte la lumière du port tout en fluidifiant la circulation des visiteurs.</p>
+            <p>Pour accueillir les artistes locaux, nous avons mixé parquet chêne fumé et dalles minérales résistantes. La pose à bâtons rompus capte la lumière du port et facilite la circulation, un concept que nous dupliquons dans plusieurs galeries parisiennes.</p>
             <div class="author"> <img src="images/author06.jpg" alt="Designer d'intérieur RenoGo"> <span>par <b>Sarah, designer d'intérieur</b></span> </div>
             <!-- end author -->
                          </div>
@@ -336,7 +336,7 @@
                            </figure>
           <div class="content"> <small>23 janvier 2024</small>
             <h3><a href="news-single.html">Cherbourg : un potager partagé pour reconnecter les collaborateurs</a></h3>
-            <p>Dans une zone d'activités, RenoGo a créé un potager collectif, arrosé par récupération d'eau de pluie et éclairé en basse consommation. Les équipes y cultivent désormais tomates et cohésion.</p>
+            <p>Dans une zone d'activités, RenoGo a créé un potager collectif alimenté par récupération d'eau de pluie et éclairé en basse consommation. Ce modèle de paysage productif est en cours de déploiement sur un campus tertiaire à Nanterre.</p>
             <div class="author"> <img src="images/author07.jpg" alt="Chef d'équipe espaces verts"> <span>par <b>Julien, chef d'équipe espaces verts</b></span> </div>
             <!-- end author -->
                          </div>
@@ -350,7 +350,7 @@
                            </figure>
           <div class="content"> <small>15 janvier 2024</small>
             <h3><a href="news-single.html">Évreux : cloisonnement modulaire et acoustique soignée dans une salle de réunion</a></h3>
-            <p>Nous avons installé des cloisons amovibles, une isolation phonique renforcée et un système multimédia intuitif. Les réunions hybrides gagnent en confort et les équipes profitent d'une flexibilité totale.</p>
+            <p>Nous avons installé des cloisons amovibles, une isolation phonique renforcée et un système multimédia intuitif. Les réunions hybrides gagnent en confort et le site est prêt pour des équipes itinérantes entre Évreux et Paris.</p>
             <div class="author"> <img src="images/author08.jpg" alt="Expert cloisonnement RenoGo"> <span>par <b>Olivier, expert cloisonnement</b></span> </div>
             <!-- end author -->
                          </div>
@@ -364,7 +364,7 @@
                            </figure>
           <div class="content"> <small>8 janvier 2024</small>
             <h3><a href="news-single.html">Fécamp : ravalement et isolation extérieure face aux embruns</a></h3>
-            <p>Sur le front de mer, RenoGo a protégé une copropriété grâce à un enduit respirant, une isolation extérieure performante et une ventilation repensée. Le bâtiment résiste désormais aux embruns tout en économisant l'énergie.</p>
+            <p>Sur le front de mer, RenoGo a protégé une copropriété grâce à un enduit respirant, une isolation extérieure performante et une ventilation repensée. Une expertise que nous mettons également au service des façades exposées de Boulogne-Billancourt.</p>
             <div class="author"> <img src="images/author09.jpg" alt="Façadier RenoGo"> <span>par <b>Hugo, façadier</b></span> </div>
             <!-- end author -->
                          </div>
@@ -378,7 +378,7 @@
                            </figure>
           <div class="content"> <small>20 décembre 2023</small>
             <h3><a href="news-single.html">Lisieux : maison connectée et sécurisée pour une famille nombreuse</a></h3>
-            <p>Alarme centralisée, gestion du chauffage pièce par pièce et scénarios lumineux : la domotique RenoGo accompagne les allers-retours domicile-école. Les parents pilotent tout depuis leur smartphone en un geste.</p>
+            <p>Alarme centralisée, gestion du chauffage pièce par pièce et scénarios lumineux : la domotique RenoGo accompagne les allers-retours domicile-école. Les parents pilotent tout depuis leur smartphone en un geste, même lorsqu’ils travaillent à Paris.</p>
             <div class="author"> <img src="images/author10.jpg" alt="Conseillère smart home"> <span>par <b>Anaïs, conseillère smart home</b></span> </div>
             <!-- end author -->
                          </div>
@@ -392,7 +392,7 @@
                            </figure>
           <div class="content"> <small>12 décembre 2023</small>
             <h3><a href="news-single.html">Granville : intervention corrective express après une tempête</a></h3>
-            <p>Suite à une coupure électrique, nos équipes d'astreinte ont sécurisé les installations, remplacé le tableau et rétabli la production d'une PME agroalimentaire en 24 heures chrono.</p>
+            <p>Suite à une coupure électrique, nos équipes d'astreinte ont sécurisé les installations, remplacé le tableau et rétabli la production d'une PME agroalimentaire en 24 heures chrono, coordonnant les stocks avec leur entrepôt francilien.</p>
             <div class="author"> <img src="images/author11.jpg" alt="Technicien astreinte RenoGo"> <span>par <b>Yanis, technicien astreinte</b></span> </div>
             <!-- end author -->
                          </div>
@@ -420,12 +420,12 @@
                                 <h6 class="widget-title">CATÉGORIES</h6>
                                 <ul class="categories">
                                                 <li><a href="#">Jardinage & Paysage</a></li>
-                                                <li><a href="#">Électricité & Domotique</a></li>
-                                                <li><a href="#">Peinture & Décoration</a></li>
-                                                <li><a href="#">Cloisons & Isolation</a></li>
-                                                <li><a href="#">Revêtements de sol</a></li>
-                                                <li><a href="#">Maintenance préventive</a></li>
-                                                <li><a href="#">Chantiers d'urgence</a></li>
+                                                <li><a href="#">Rénovation énergétique</a></li>
+                                                <li><a href="#">Électricité & Smart Building</a></li>
+                                                <li><a href="#">Aménagement intérieur</a></li>
+                                                <li><a href="#">Revêtements & finitions</a></li>
+                                                <li><a href="#">Maintenance multitechnique</a></li>
+                                                <li><a href="#">Interventions d'urgence</a></li>
                                         </ul>
                                 </div>
                                 <!-- end widget -->
@@ -456,14 +456,14 @@
       <div class="col-12">
 
           <figure class="logo"> <img src="images/logo.png" alt="RenoGo"> </figure>
-          <h2>Vivez <b>mieux</b> et <b>plus serein</b> avec RenoGo</h2>
-          <a href="contact.html" class="button">OBTENIR UN DEVIS <i class="lni lni-arrow-right"></i></a>
+          <h2>Passez de l’idée au chantier avec <b>RenoGo</b></h2>
+          <a href="contact.html" class="button">PLANIFIER UN RENDEZ-VOUS <i class="lni lni-arrow-right"></i></a>
                   <div class="sales-representive">
                         <figure>
                                 <img src="images/author12.jpg" alt="Conseiller RenoGo">
-                          </figure>Votre conseiller dédié
+                          </figure>Votre conseiller Normandie & Île-de-France
 
-                          <b>+33 1 84 80 12 45</b> appel gratuit !
+                          <b>+33 1 84 80 12 45</b> — appel gratuit
                   </div>
                   <!-- end sales-representive -->
                 </div>
@@ -500,7 +500,7 @@
       <!-- end col-6 -->
                 <div class="col-12">
                         <div class="footer-bottom">
-                                <span>© 2024 RenoGo | Rénovation, maintenance et aménagements en Normandie</span>
+                                <span>© 2025 RenoGo • Rénovation & maintenance immobilière – Normandie & Île-de-France</span>
                                 <ul>
                                 <li><a href="#">Facebook</a></li>
                                 <li><a href="#">Instagram</a></li>

--- a/projects.html
+++ b/projects.html
@@ -6,8 +6,8 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <!-- Primary SEO -->
-  <title>RenoGo • Rénovation intérieure & amélioration de l’habitat en France</title>
-  <meta name="description" content="RenoGo rénove et transforme appartements et maisons : cuisines, salles de bain, isolation, électricité, peinture. Devis rapide, travaux qualitatifs, livrés à temps.">
+  <title>Réalisations RenoGo • Rénovations & projets pilotes en Normandie et Île-de-France</title>
+  <meta name="description" content="Découvrez les projets RenoGo : rénovation énergétique, aménagement d’espaces, modernisation de bureaux et maintenance de copropriétés en Normandie et Île-de-France.">
   <link rel="canonical" href="https://www.renogo.fr/">
 
   <!-- Indexing -->
@@ -29,8 +29,8 @@
   <meta property="og:locale" content="fr_FR">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="RenoGo">
-  <meta property="og:title" content="RenoGo • Rénovation intérieure & amélioration de l’habitat">
-  <meta property="og:description" content="Cuisine, salle de bain, peinture, isolation et plus. Devis rapide, travaux maîtrisés.">
+  <meta property="og:title" content="Réalisations RenoGo • Rénovation & maintenance immobilière">
+  <meta property="og:description" content="Études de cas : logements, bureaux, commerces, hôtels et copropriétés pilotés par RenoGo en Normandie et Île-de-France.">
   <meta property="og:url" content="https://www.renogo.fr/">
   <meta property="og:image" content="https://www.renogo.fr/assets/og/renogo-cover.jpg">
   <meta property="og:image:width" content="1200">
@@ -39,8 +39,8 @@
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@renogo">
-  <meta name="twitter:title" content="RenoGo • Rénovation intérieure & amélioration de l’habitat">
-  <meta name="twitter:description" content="Rénovation d’appartements et maisons en France. Devis rapide, délais tenus.">
+  <meta name="twitter:title" content="Réalisations RenoGo • Rénovation & maintenance immobilière">
+  <meta name="twitter:description" content="Projets livrés : rénovation énergétique, fit-out tertiaire, paysages sur mesure et maintenance multitechnique.">
   <meta name="twitter:image" content="https://www.renogo.fr/assets/og/renogo-cover.jpg">
 
   <!-- Organization -->
@@ -75,7 +75,7 @@
     "url": "https://www.renogo.fr/",
     "logo": "https://www.renogo.fr/assets/logo/renogo-logo.svg",
     "image": "https://www.renogo.fr/assets/og/renogo-cover.jpg",
-    "description": "Rénovation intérieure d’appartements et maisons : cuisines, salles de bain, isolation, électricité, peinture.",
+    "description": "Rénovation globale, efficacité énergétique, design d’espace et maintenance immobilière en Normandie et Île-de-France.",
     "telephone": "+33-1-23-45-67-89",
     "areaServed": "FR",
     "priceRange": "€€",
@@ -144,10 +144,10 @@
 
     <div class="hide-mobile">
       <p>
-        RenoGo accompagne vos projets de rénovation et d’entretien en Normandie :
-        <u>électricité & éclairage</u>, <u>peinture & sols</u>, <u>cloisons & isolation</u>,
-        <u>jardinage & aménagement paysager</u>, ainsi que <u>domotique / maison intelligente</u>.
-        Des chantiers propres, des délais tenus, un suivi de proximité.
+        RenoGo coordonne vos projets de rénovation, d’aménagement et de maintenance immobilière en Normandie et en Île-de-France :
+        <u>rénovation énergétique</u>, <u>second œuvre</u>, <u>domotique & smart building</u>,
+        <u>aménagement paysager</u> et <u>services multitechniques</u>.
+        Un pilotage unique, des artisans qualifiés, des livraisons sans surprise.
       </p>
 
       <figure class="gallery">
@@ -236,7 +236,7 @@
   <header class="page-header">
     <div class="container">
       <h1>Projets</h1>
-      <h6>Des scénarios réels conçus avec nos clients normands pour préparer vos futurs chantiers, même sans photos avant/après… pour l'instant.</h6>
+      <h6>Études de cas et chantiers livrés en Normandie et Île-de-France pour inspirer vos futures rénovations.</h6>
       <ul>
         <li><a href="index.html">Accueil</a></li>
         <li>Projets</li>
@@ -251,14 +251,14 @@
       <div class="row align-items-center mb-5">
         <div class="col-lg-6">
           <div class="section-title">
-            <h2>Pourquoi parler de projets avant la première pierre&nbsp;?</h2>
+            <h2>Pourquoi partager nos projets avant votre chantier&nbsp;?</h2>
           </div>
         </div>
         <div class="col-lg-6">
           <p>
-            Parce que chaque maison normande, chaque bureau avec vue sur la Manche ou la Seine, mérite une préparation millimétrée.
-            RenoGo travaille en amont sur la faisabilité, les autorisations, le choix des matériaux résistants à l'air marin ou à l'humidité du bocage.
-            Nous partageons ici nos inspirations et projets pilotes afin que vous puissiez vous projeter avec confiance.
+            Parce que chaque maison normande, appartement parisien ou plateau tertiaire mérite une préparation millimétrée.
+            RenoGo sécurise la faisabilité, les autorisations, les études énergétiques et la sélection des matériaux adaptés à l’air marin comme aux immeubles haussmanniens.
+            Nous partageons ici nos réalisations et projets pilotes pour que vous visualisiez la méthode et les résultats obtenus.
           </p>
         </div>
       </div>
@@ -268,21 +268,21 @@
           <div class="icon-content">
             <figure><img src="images/icon01.png" alt="Études personnalisées"></figure>
             <h3>Études personnalisées</h3>
-            <small>Diagnostics techniques, relevés 3D et estimations budgétaires pour Caen, Rouen, Alençon ou Cherbourg.</small>
+            <small>Diagnostics techniques, relevés 3D et estimations budgétaires pour Caen, Rouen, Paris, Versailles ou Cherbourg.</small>
           </div>
         </div>
         <div class="col-md-4">
           <div class="icon-content">
             <figure><img src="images/icon02.png" alt="Artisans sélectionnés"></figure>
             <h3>Artisans sélectionnés</h3>
-            <small>Un réseau de partenaires normands certifiés RGE, Qualifelec ou QualiPaysage, coordonnés par nos chefs de projet.</small>
+            <small>Un réseau d’artisans normands et franciliens certifiés RGE, Qualifelec, Qualibat ou QualiPaysage coordonnés par nos chefs de projet.</small>
           </div>
         </div>
         <div class="col-md-4">
           <div class="icon-content">
             <figure><img src="images/icon03.png" alt="Suivi digital"></figure>
             <h3>Suivi digital</h3>
-            <small>Planning partagé, comptes rendus hebdomadaires et domotique prête à configurer depuis votre smartphone.</small>
+            <small>Planning partagé, comptes rendus hebdomadaires, photos chantier et domotique prête à configurer à distance.</small>
           </div>
         </div>
       </div>
@@ -322,7 +322,7 @@
                 </a>
                 <figcaption>
                   <h5>Deauville • Villa secondaire connectée</h5>
-                  <p>Installation domotique complète : chauffage pilotable, scénarios lumineux doux pour les week-ends, sécurité périmétrique et bornes de recharge discrètes.</p>
+                  <p>Installation domotique complète pilotable depuis Paris : chauffage intelligent, scénarios lumineux, sécurité périmétrique et bornes de recharge discrètes.</p>
                   <span>Statut : sélection des équipements smart home en cours</span>
                 </figcaption>
               </figure>
@@ -377,8 +377,8 @@
                   <img src="images/slide05.jpg" alt="Simulation d'un plateau tertiaire à Le Havre">
                 </a>
                 <figcaption>
-                  <h5>Le Havre • Bureaux intelligents</h5>
-                  <p>Relamping LED, détection de présence, prises connectées et maintenance préventive centralisée pour un siège social près des docks.</p>
+                  <h5>La Défense • Bureaux intelligents</h5>
+                  <p>Relamping LED, détection de présence, GTB et maintenance préventive centralisée pour un siège social multi-sites Normandie/Île-de-France.</p>
                   <span>Statut : audit énergétique terminé, lot électricité en lancement</span>
                 </figcaption>
               </figure>
@@ -405,9 +405,9 @@
                   <img src="images/slide02.jpg" alt="Perspective d'un hall d'immeuble rénové à Évreux">
                 </a>
                 <figcaption>
-                  <h5>Évreux • Immeuble copropriété sereine</h5>
-                  <p>Remise aux normes électriques, reprise des cloisons coupe-feu, revêtements de sol grand passage et plan de maintenance annuel.</p>
-                  <span>Statut : vote des copropriétaires obtenu à l'unanimité</span>
+                  <h5>Versailles • Copropriété sécurisée</h5>
+                  <p>Remise aux normes électriques, renforcement coupe-feu, revêtements de sol grand passage et contrat de maintenance annuel.</p>
+                  <span>Statut : vote des copropriétaires obtenu à l’unanimité</span>
                 </figcaption>
               </figure>
             </li>
@@ -433,8 +433,8 @@
         <div class="col-lg-7">
           <p>
             Avant même le premier coup de pinceau, nous engageons une relation de confiance : comptes rendus partagés,
-            assurance décennale, interlocuteur unique, visites de contrôle hebdomadaires.
-            Chaque projet présenté ici est déjà sécurisé par un calendrier détaillé et des devis fermes validés avec nos partenaires.
+            assurance décennale, interlocuteur unique et visites de contrôle hebdomadaires.
+            Chaque projet présenté ici s’appuie sur un calendrier détaillé, des devis fermes et des partenaires audités.
           </p>
         </div>
       </div>
@@ -443,11 +443,11 @@
           <div class="icon-content">
             <h3>Process en 5 étapes</h3>
             <ul>
-              <li>1. Rendez-vous inspiration chez vous ou en visio depuis Paris.</li>
-              <li>2. Relevés techniques et modélisation 3D pour anticiper chaque détail.</li>
-              <li>3. Consultation des artisans normands et consolidation des devis.</li>
-              <li>4. Planification des travaux par lot, suivi des approvisionnements.</li>
-              <li>5. Réception contrôlée et maintenance préventive programmée.</li>
+              <li>1. Rendez-vous inspiration sur site ou en visio depuis Paris/Normandie.</li>
+              <li>2. Relevés techniques, audit énergétique et modélisation 3D.</li>
+              <li>3. Consultation d’artisans certifiés et consolidation des devis fermes.</li>
+              <li>4. Planification multi-lots, suivi logistique et sécurité chantier.</li>
+              <li>5. Réception contrôlée, DOE numérique et maintenance préventive programmée.</li>
             </ul>
           </div>
         </div>
@@ -455,11 +455,11 @@
           <div class="icon-content">
             <h3>Vos bénéfices concrets</h3>
             <ul>
-              <li>Délais réalistes grâce à une logistique depuis notre hub de Pont-l'Évêque.</li>
-              <li>Démarches administratives (DP, CEE, aides MaPrimeRénov') prises en charge.</li>
-              <li>Matériaux adaptés au climat normand : anti-corrosion, anti-humidité, essences locales.</li>
-              <li>Budget maîtrisé avec un suivi des dépenses en temps réel.</li>
-              <li>Service après-vente : visites saisonnières jardin &amp; maintenance électrique.</li>
+              <li>Délais réalistes grâce à nos hubs logistiques en Normandie et en région parisienne.</li>
+              <li>Démarches administratives (DP, CEE, MaPrimeRénov’, ERP) prises en charge.</li>
+              <li>Matériaux adaptés aux climats marin et urbain : anti-corrosion, anti-humidité, acoustique.</li>
+              <li>Budget maîtrisé avec un suivi des dépenses et des économies d’énergie en temps réel.</li>
+              <li>Service après-vente : visites saisonnières, maintenance multitechnique et hotline dédiée.</li>
             </ul>
           </div>
         </div>
@@ -472,7 +472,7 @@
       <div class="row">
         <div class="col-12 text-center">
           <figure class="logo"><img src="images/logo.png" alt="Logo RenoGo"></figure>
-          <h2>Imaginons ensemble le futur de votre bien normand</h2>
+          <h2>Imaginons ensemble le futur de votre patrimoine en Normandie & Île-de-France</h2>
           <a href="contact.html" class="button">PLANIFIER UN RENDEZ-VOUS <i class="lni lni-arrow-right"></i></a>
           <div class="sales-representive">
             <figure>
@@ -515,7 +515,7 @@
         <!-- end col-6 -->
         <div class="col-12">
           <div class="footer-bottom">
-            <span>© 2024 RenoGo | Rénovation, entretien et maintenance en Normandie</span>
+            <span>© 2025 RenoGo • Rénovation & maintenance immobilière – Normandie & Île-de-France</span>
             <ul>
               <li><a href="#">Facebook</a></li>
               <li><a href="#">Instagram</a></li>

--- a/services.html
+++ b/services.html
@@ -6,8 +6,8 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <!-- Primary SEO -->
-  <title>RenoGo • Rénovation intérieure & amélioration de l’habitat en France</title>
-  <meta name="description" content="RenoGo rénove et transforme appartements et maisons : cuisines, salles de bain, isolation, électricité, peinture. Devis rapide, travaux qualitatifs, livrés à temps.">
+  <title>Services RenoGo • Rénovation, efficacité énergétique & maintenance en Normandie – Île-de-France</title>
+  <meta name="description" content="Explorez les services RenoGo : rénovation globale, second œuvre, ingénierie énergétique, aménagement d’espaces, smart building et maintenance immobilière pour particuliers et professionnels.">
   <link rel="canonical" href="https://www.renogo.fr/">
 
   <!-- Indexing -->
@@ -29,8 +29,8 @@
   <meta property="og:locale" content="fr_FR">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="RenoGo">
-  <meta property="og:title" content="RenoGo • Rénovation intérieure & amélioration de l’habitat">
-  <meta property="og:description" content="Cuisine, salle de bain, peinture, isolation et plus. Devis rapide, travaux maîtrisés.">
+  <meta property="og:title" content="Services RenoGo • Rénovation & maintenance immobilière">
+  <meta property="og:description" content="Contractant général pour rénovations globales, travaux énergétiques, aménagements de bureaux et entretien multitechnique.">
   <meta property="og:url" content="https://www.renogo.fr/">
   <meta property="og:image" content="https://www.renogo.fr/assets/og/renogo-cover.jpg">
   <meta property="og:image:width" content="1200">
@@ -39,8 +39,8 @@
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@renogo">
-  <meta name="twitter:title" content="RenoGo • Rénovation intérieure & amélioration de l’habitat">
-  <meta name="twitter:description" content="Rénovation d’appartements et maisons en France. Devis rapide, délais tenus.">
+  <meta name="twitter:title" content="Services RenoGo • Rénovation & maintenance immobilière">
+  <meta name="twitter:description" content="Solutions clés en main : rénovation énergétique, design d’intérieur, fit-out tertiaire et contrats de maintenance.">
   <meta name="twitter:image" content="https://www.renogo.fr/assets/og/renogo-cover.jpg">
 
   <!-- Organization -->
@@ -75,7 +75,7 @@
     "url": "https://www.renogo.fr/",
     "logo": "https://www.renogo.fr/assets/logo/renogo-logo.svg",
     "image": "https://www.renogo.fr/assets/og/renogo-cover.jpg",
-    "description": "Rénovation intérieure d’appartements et maisons : cuisines, salles de bain, isolation, électricité, peinture.",
+    "description": "Rénovation globale, efficacité énergétique, design d’espace, smart building et maintenance immobilière.",
     "telephone": "+33-1-23-45-67-89",
     "areaServed": "FR",
     "priceRange": "€€",
@@ -144,10 +144,10 @@
 
     <div class="hide-mobile">
       <p>
-        RenoGo accompagne vos projets de rénovation et d’entretien en Normandie :
-        <u>électricité & éclairage</u>, <u>peinture & sols</u>, <u>cloisons & isolation</u>,
-        <u>jardinage & aménagement paysager</u>, ainsi que <u>domotique / maison intelligente</u>.
-        Des chantiers propres, des délais tenus, un suivi de proximité.
+        RenoGo coordonne vos projets de rénovation, d’aménagement et de maintenance immobilière en Normandie et en Île-de-France :
+        <u>rénovation énergétique</u>, <u>second œuvre</u>, <u>domotique & smart building</u>,
+        <u>aménagement paysager</u> et <u>services multitechniques</u>.
+        Un pilotage unique, des artisans qualifiés, des livraisons sans surprise.
       </p>
 
       <figure class="gallery">
@@ -235,7 +235,7 @@
 <header class="page-header">
   <div class="container">
     <h1>Services</h1>
-    <h6>De la première visite à l'entretien sur le long terme, RenoGo orchestre chaque détail pour vos espaces de vie et de travail.</h6>
+    <h6>Solutions clés en main pour rénover, optimiser et maintenir vos biens en Normandie et Île-de-France.</h6>
     <ul>
       <li><a href="index.html">Accueil</a></li>
       <li>Services</li>
@@ -251,7 +251,7 @@
         <div class="icon-content">
           <figure><img src="images/icon01.png" alt="Proximité terrain"></figure>
           <h3>Experts de proximité</h3>
-          <small>Nos chefs de projet sillonnent la Normandie pour une réponse rapide et personnalisée à Caen, Rouen, Cherbourg ou Bayeux.</small> <a href="#services-jardin">+</a> </div>
+          <small>Chefs de projet basés à Paris et en Normandie pour une réponse rapide à Caen, Rouen, Paris, La Défense ou Versailles.</small> <a href="#services-jardin">+</a> </div>
         <!-- end icon-content -->
       </div>
       <!-- end col-4 -->
@@ -259,7 +259,7 @@
         <div class="icon-content">
           <figure><img src="images/icon02.png" alt="Innovation durable"></figure>
           <h3>Durabilité & innovation</h3>
-          <small>Solutions bas carbone, domotique intuitive et matériaux certifiés pour un confort durable à la normande.</small> <a href="#services-electricite">+</a> </div>
+          <small>Solutions bas carbone, domotique, HVAC et matériaux certifiés pour réduire vos charges et votre empreinte.</small> <a href="#services-electricite">+</a> </div>
         <!-- end icon-content -->
       </div>
       <!-- end col-4 -->
@@ -267,7 +267,7 @@
         <div class="icon-content">
           <figure><img src="images/icon03.png" alt="Suivi premium"></figure>
           <h3>Suivi clé en main</h3>
-          <small>Planning partagé, interlocuteur unique et maintenance préventive pour des chantiers sans surprises.</small> <a href="#accompagnement-renogo">+</a> </div>
+          <small>Interlocuteur unique, reporting digital, maintenance préventive et service desk pour des chantiers sans surprises.</small> <a href="#accompagnement-renogo">+</a> </div>
         <!-- end icon-content -->
       </div>
       <!-- end col-4 -->
@@ -282,14 +282,14 @@
     <div class="row justify-content-end">
       <div class="col-lg-6 col-md-9">
         <div class="services-list-box">
-          <h4>Un partenaire unique pour vos espaces</h4>
-          <p>Notre équipe pluridisciplinaire s'engage auprès des particuliers, syndics et entreprises pour transformer et entretenir les biens normands. Chaque mission commence par une immersion sur site, l'écoute de vos usages et la co-construction d'une feuille de route opérationnelle.</p>
+          <h4>Un partenaire unique pour vos actifs immobiliers</h4>
+          <p>Nos équipes pluridisciplinaires accompagnent particuliers, investisseurs, syndics et entreprises pour rénover, moderniser et entretenir leurs biens en Normandie et Île-de-France. Chaque mission débute par un audit, un plan de phasage et un pilotage rigoureux des intervenants.</p>
           <ul>
-            <li>Visite conseil et audit technique offerts sur Caen, Rouen et Le Havre</li>
-            <li>Pilotage de projets avec planning, budget et reporting transparent</li>
-            <li>Maintenance préventive et dépannage 6j/7 avec astreinte hivernale</li>
-            <li>Matériaux sélectionnés pour résister au climat marin normand</li>
-            <li>Garanties décennales et service après-travaux proactif</li>
+            <li>Audit technique, énergétique et réglementaire sur site ou à distance</li>
+            <li>Planning, budget et reporting digital accessibles en temps réel</li>
+            <li>Coordination des corps d’état, contrôle qualité et levée de réserves</li>
+            <li>Contrats de maintenance préventive et astreinte multi-sites</li>
+            <li>Garanties décennales, DOE numérique et service après-travaux proactif</li>
           </ul>
           <a href="contact.html" class="button">DEMANDER UN DIAGNOSTIC</a> </div>
         <!-- end services-list-box -->
@@ -306,16 +306,16 @@
     <div class="row">
       <div class="col-lg-3 col-md-6">
         <div class="counter-box"> <span class="odometer" data-count="120" data-status="yes">0</span> <span class="value">+</span>
-          <h6>Chantiers annuels en Normandie</h6>
-          <p>Maisons anciennes, villas balnéaires, locaux tertiaires et commerces accompagnés chaque année.</p>
+          <h6>Chantiers annuels livrés</h6>
+          <p>Maisons, bureaux, commerces et hôtels transformés chaque année en Normandie et Île-de-France.</p>
         </div>
         <!-- end counter-box -->
       </div>
       <!-- end col-3 -->
       <div class="col-lg-3 col-md-6">
         <div class="counter-box"> <span class="odometer" data-count="48" data-status="yes">0</span> <span class="value">h</span>
-          <h6>Délai moyen d'intervention</h6>
-          <p>Une organisation agile pour sécuriser vos biens même en période de tempête ou de fortes marées.</p>
+          <h6>Délai moyen d’intervention</h6>
+          <p>48 heures pour mobiliser nos équipes d’audit et sécuriser vos biens en cas d’urgence.</p>
         </div>
         <!-- end counter-box -->
       </div>
@@ -323,15 +323,15 @@
       <div class="col-lg-3 col-md-6">
         <div class="counter-box"> <span class="odometer" data-count="87" data-status="yes">0</span> <span class="value">%</span>
           <h6>Clients fidèles</h6>
-          <p>Familles, bailleurs sociaux et PME nous confient leurs projets sur le long terme.</p>
+          <p>Familles, investisseurs, bailleurs sociaux et PME renouvellent leur confiance année après année.</p>
         </div>
         <!-- end counter-box -->
       </div>
       <!-- end col-3 -->
       <div class="col-lg-3 col-md-6">
         <div class="counter-box"> <span class="odometer" data-count="5" data-status="yes">0</span> <span class="value"> métiers</span>
-          <h6>Compétences complémentaires</h6>
-          <p>Jardin, électricité, peinture, cloisons & isolation, sols : un bouquet de services coordonnés.</p>
+          <h6>Compétences coordonnées</h6>
+          <p>Second œuvre, CVC, smart building, paysage et maintenance : un bouquet de services orchestrés.</p>
         </div>
         <!-- end counter-box -->
       </div>
@@ -348,13 +348,13 @@
       <div class="col-lg-7">
         <div class="section-title text-left">
           <h6>NOTRE MÉTHODOLOGIE</h6>
-          <h2>Une approche en trois temps pour un résultat impeccable</h2>
+          <h2>Une approche en trois temps pour des chantiers maîtrisés</h2>
         </div>
         <!-- end section-title -->
       </div>
       <!-- end col-7 -->
       <div class="col-lg-5">
-        <p>Chaque projet RenoGo s'écrit avec vous : diagnostic précis, design sur mesure, exécution millimétrée et suivi préventif. Notre connaissance des architectures normandes, de la météo côtière et des contraintes énergétiques garantit des chantiers pérennes.</p>
+        <p>Chaque projet RenoGo s’écrit avec vous : diagnostic technique, conception sur mesure, exécution contrôlée et maintenance continue. Notre connaissance du bâti normand et francilien garantit des chantiers performants et pérennes.</p>
       </div>
       <!-- end col-5 -->
       <div class="col-lg-4">
@@ -363,7 +363,7 @@
           <div class="content"> <span>01.</span>
             <figure class="icon"><img src="images/icon01.png" alt="Audit"></figure>
             <h6>Analyse & inspiration</h6>
-            <p>Relevés techniques, inspirations locales, sélection de matériaux adaptés aux embruns et à l'humidité.</p>
+            <p>Relevés techniques, audit énergétique, analyse des usages et cadrage budgétaire.</p>
           </div>
           <!-- end content -->
         </div>
@@ -376,7 +376,7 @@
           <div class="content"> <span>02.</span>
             <figure class="icon"><img src="images/icon02.png" alt="Planification"></figure>
             <h6>Conception & planification</h6>
-            <p>Scénarios 3D, choix de couleurs et éclairages, phasage des corps d'état pour limiter l'immobilisation.</p>
+            <p>Conception 3D, choix de matériaux durables, planification des corps d’état et logistique chantier.</p>
           </div>
           <!-- end content -->
         </div>
@@ -389,7 +389,7 @@
           <div class="content"> <span>03.</span>
             <figure class="icon"><img src="images/icon03.png" alt="Suivi"></figure>
             <h6>Réalisation & entretien</h6>
-            <p>Équipes qualifiées, contrôles qualité continus et mise en place d'un contrat d'entretien saisonnier.</p>
+            <p>Exécution par des artisans certifiés, contrôle qualité continu, DOE numérique et contrat d’entretien.</p>
           </div>
           <!-- end content -->
         </div>
@@ -407,7 +407,7 @@
     <div class="row align-items-center no-gutters">
       <div class="col-lg-5">
         <div class="tab-left">
-          <h2>Des expertises complémentaires pour un chantier harmonieux</h2>
+          <h2>Des expertises coordonnées pour des espaces performants</h2>
           <ul class="tab-nav">
             <li class="active"><a href="#tab01" id="services-jardin">Jardin & Paysage</a></li>
             <li><a href="#tab02" id="services-electricite">Électricité & Smart Home</a></li>
@@ -415,7 +415,7 @@
             <li><a href="#tab04">Cloisons, Plâtrerie & Isolation</a></li>
             <li><a href="#tab05">Sols & Revêtements</a></li>
           </ul>
-          <p>Nos équipes partagent une même exigence : préserver le cachet normand tout en intégrant les innovations qui simplifient le quotidien. Chaque lot est orchestré par un conducteur de travaux dédié pour que tout s'enchaine naturellement.</p>
+          <p>Nos équipes combinent savoir-faire artisanal et technologies smart building pour livrer des intérieurs et extérieurs durables. Chaque lot est piloté par un conducteur de travaux unique pour garantir qualité, délais et budget.</p>
         </div>
         <!-- end tab-left -->
       </div>
@@ -425,40 +425,40 @@
           <div id="tab01" class="tab-item active-item">
             <img src="images/tab01.jpg" alt="Aménagement paysager">
             <div class="tab-text">
-              <h3>Respirer l'art de vivre normand</h3>
-              <p>Création de jardins côtiers résistants au sel, terrasses en bois traité, potagers familiaux et entretien annuel : tonte, taille douce, désherbage écologique, préparation aux tempêtes et installation d'arrosages connectés.</p>
+              <h3>Paysages & terrasses à vivre</h3>
+              <p>Création de jardins, terrasses bois, patios et potagers urbains. Entretien annuel, arrosages intelligents, éclairage extérieur et préparation aux intempéries.</p>
             </div>
           </div>
           <!-- end tab01 -->
           <div id="tab02" class="tab-item">
             <img src="images/tab02.jpg" alt="Installation électrique">
             <div class="tab-text">
-              <h3>Énergie sécurisée & connectée</h3>
-              <p>Mises aux normes, tableaux électriques intelligents, éclairages d'ambiance, bornes de recharge, alarmes et domotique pour piloter chauffage, volets et éclairage à distance. Service de maintenance corrective et préventive 6j/7.</p>
+              <h3>Énergie & smart building</h3>
+              <p>Mises aux normes, tableaux communicants, éclairages LED, bornes IRVE, GTB, sécurité incendie, domotique et optimisation CVC. Maintenance préventive et corrective 6j/7.</p>
             </div>
           </div>
           <!-- end tab02 -->
           <div id="tab03" class="tab-item">
             <img src="images/tab03.jpg" alt="Travaux de peinture">
             <div class="tab-text">
-              <h3>Couleurs qui dialoguent avec la lumière normande</h3>
-              <p>Diagnostic des supports, traitement anti-humidité, peintures biosourcées, finitions décoratives, fresques contemporaines ou patines esprit maison de famille. Protection totale du mobilier et nettoyage minutieux en fin de chantier.</p>
+              <h3>Peinture & design d’intérieur</h3>
+              <p>Diagnostic des supports, traitements anti-humidité, peintures biosourcées, finitions décoratives et mises en couleur sur mesure pour logements, hôtels et bureaux.</p>
             </div>
           </div>
           <!-- end tab03 -->
           <div id="tab04" class="tab-item">
             <img src="images/tab04.jpg" alt="Isolation performante">
             <div class="tab-text">
-              <h3>Confort thermique toute l'année</h3>
-              <p>Création de cloisons acoustiques, doublages isolants biosourcés, traitement des combles, solutions coupe-feu pour les ERP et optimisation des performances énergétiques pour bénéficier des aides locales.</p>
+              <h3>Isolation & confort acoustique</h3>
+              <p>Cloisons techniques, doublages isolants biosourcés, traitement des combles, solutions coupe-feu ERP, amélioration énergétique et accompagnement aides financières.</p>
             </div>
           </div>
           <!-- end tab04 -->
           <div id="tab05" class="tab-item">
             <img src="images/tab05.jpg" alt="Pose de sols">
             <div class="tab-text">
-              <h3>Sols résistants aux saisons normandes</h3>
-              <p>Parquets massifs ou contrecollés, carrelages grand format, sols souples acoustiques, résines techniques pour locaux professionnels et terrasses extérieures antidérapantes.</p>
+              <h3>Sols & revêtements haute résistance</h3>
+              <p>Parquets, carrelages grand format, sols LVT acoustiques, résines techniques pour ERP et terrasses antidérapantes adaptées aux climats normand et francilien.</p>
             </div>
           </div>
           <!-- end tab05 -->
@@ -477,8 +477,8 @@
     <div class="row no-gutters">
       <div class="col-12">
         <div class="section-title text-left">
-          <h6>PARTOUT EN NORMANDIE</h6>
-          <h2>Nous intervenons pour</h2>
+          <h6>SECTEURS SERVIS</h6>
+          <h2>Nous accompagnons</h2>
         </div>
         <!-- end section-title -->
       </div>
@@ -486,7 +486,7 @@
       <div class="col-lg-4 col-md-6"> <a href="projects.html" class="sector-box"> <span>Résidences principales & secondaires</span> <i class="lni lni-arrow-right"></i> </a> </div>
       <!-- end col-4 -->
 
-      <div class="col-lg-4 col-md-6"> <a href="projects.html" class="sector-box"> <span>Maisons à colombages & patrimoine</span> <i class="lni lni-arrow-right"></i> </a> </div>
+      <div class="col-lg-4 col-md-6"> <a href="projects.html" class="sector-box"> <span>Patrimoine & rénovations premium</span> <i class="lni lni-arrow-right"></i> </a> </div>
       <!-- end col-4 -->
 
       <div class="col-lg-4 col-md-6"> <a href="projects.html" class="sector-box"> <span>Bureaux, commerces & coworkings</span> <i class="lni lni-arrow-right"></i> </a> </div>
@@ -495,10 +495,10 @@
       <div class="col-lg-4 col-md-6"> <a href="projects.html" class="sector-box"> <span>Hôtels, gîtes & locations saisonnières</span> <i class="lni lni-arrow-right"></i> </a> </div>
       <!-- end col-4 -->
 
-      <div class="col-lg-4 col-md-6"> <a href="projects.html" class="sector-box"> <span>Bâtiments publics & collectivités</span> <i class="lni lni-arrow-right"></i> </a> </div>
+      <div class="col-lg-4 col-md-6"> <a href="projects.html" class="sector-box"> <span>Bâtiments publics & établissements de santé</span> <i class="lni lni-arrow-right"></i> </a> </div>
       <!-- end col-4 -->
 
-      <div class="col-lg-4 col-md-6"> <a href="projects.html" class="sector-box"> <span>Syndics & bailleurs sociaux</span> <i class="lni lni-arrow-right"></i> </a> </div>
+      <div class="col-lg-4 col-md-6"> <a href="projects.html" class="sector-box"> <span>Syndics, bailleurs & foncières</span> <i class="lni lni-arrow-right"></i> </a> </div>
       <!-- end col-4 -->
     </div>
     <!-- end row -->
@@ -511,11 +511,11 @@
     <div class="row">
       <div class="col-12">
         <figure class="logo"> <img src="images/logo.png" alt="RenoGo"> </figure>
-        <h2>Confiez votre projet à <b>RenoGo</b> et vivez la sérénité normande</h2>
-        <a href="contact.html" class="button">OBTENIR UN RENDEZ-VOUS <i class="lni lni-arrow-right"></i></a>
+        <h2>Confiez votre projet à <b>RenoGo</b> et pilotez vos chantiers en toute sérénité</h2>
+        <a href="contact.html" class="button">PLANIFIER UN RENDEZ-VOUS <i class="lni lni-arrow-right"></i></a>
         <div class="sales-representive">
           <figure> <img src="images/author01.jpg" alt="Conseiller RenoGo"> </figure>
-          Conseillère dédiée Normandie <b>+33 (0)1 86 90 12 45</b> appel gratuit ! </div>
+          Conseiller dédié Normandie & Île-de-France <b>+33 (0)1 86 90 12 45</b> — appel gratuit</div>
         <!-- end sales-representive -->
       </div>
       <!-- end col-12  -->
@@ -548,7 +548,7 @@
       </div>
       <!-- end col-6 -->
       <div class="col-12">
-        <div class="footer-bottom"> <span>© 2024 RenoGo | Rénovation, entretien et maintenance en Normandie</span>
+        <div class="footer-bottom"> <span>© 2025 RenoGo • Rénovation & maintenance immobilière – Normandie & Île-de-France</span>
           <ul>
             <li><a href="#">Facebook</a></li>
             <li><a href="#">Instagram</a></li>


### PR DESCRIPTION
## Summary
- update SEO metadata, hero messaging, and storytelling across the homepage and company profile to emphasise RenoGo’s renovation and maintenance expertise in Normandy and Île-de-France
- refresh the services, projects, news, and contact pages with copy that highlights the full service portfolio, sector use cases, and tailored calls to action for homeowners, investors, and SMEs

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68df8b3be3a4832eaea3fb86c735144c