### PR TITLE
Add accreditation badge strips across site

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -244,6 +244,36 @@
   <!-- end container -->
 </header>
 <!-- end page-header -->
+<section class="content-section accreditation-wrapper">
+  <div class="container">
+    <div class="accreditation-strip" aria-label="Garanties et certifications RenoGo">
+      <div class="accreditation-badge">
+        <figure>
+          <img src="images/badge-rge.svg" alt="Label RGE Qualibat détenu par RenoGo">
+        </figure>
+        <span>Expertise RGE Qualibat</span>
+      </div>
+      <div class="accreditation-badge">
+        <figure>
+          <img src="images/badge-handibat.svg" alt="Certification d’accessibilité Handibat">
+        </figure>
+        <span>Accessibilité Handibat</span>
+      </div>
+      <div class="accreditation-badge">
+        <figure>
+          <img src="images/badge-capeb.svg" alt="Adhésion CAPEB — artisans du bâtiment">
+        </figure>
+        <span>Réseau CAPEB</span>
+      </div>
+      <div class="accreditation-badge">
+        <figure>
+          <img src="images/badge-eco-artisan.svg" alt="Mention Éco Artisan pour la performance énergétique">
+        </figure>
+        <span>Performance Éco Artisan</span>
+      </div>
+    </div>
+  </div>
+</section>
 <section class="content-section">
   <div class="container">
     <div class="row">

--- a/css/style.css
+++ b/css/style.css
@@ -1018,6 +1018,48 @@ a:hover {
 .slider .slider-content .controls .button-next:hover {
   background: #ff7a04;
 }
+
+/* ACCREDITATION STRIP */
+.accreditation-strip {
+  width: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 30px;
+  padding: 26px 36px;
+  border: 2px solid #e8e8e8;
+  border-radius: 24px;
+  background: #ffffff;
+}
+
+.accreditation-badge {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.accreditation-badge figure {
+  margin: 0;
+  width: 92px;
+}
+
+.accreditation-badge figure img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.accreditation-badge span {
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+
+.hero-badges {
+  margin-top: 60px;
+  background: rgba(255, 255, 255, 0.9);
+}
 .slider .slider-main {
   width: calc(50vw + 80px);
   height: calc(100vh - 150px);
@@ -3477,6 +3519,15 @@ input::-moz-focus-inner, input::-moz-focus-outer {
   .footer-bar h2 {
     padding: 0;
   }
+
+  .accreditation-strip {
+    gap: 24px;
+    padding: 24px 28px;
+  }
+
+  .accreditation-badge {
+    flex: 1 1 calc(50% - 24px);
+  }
 }
 /* RESPONSIVE TABLET  */
 @media only screen and (max-width: 991px), only screen and (max-device-width: 991px) {
@@ -3554,6 +3605,16 @@ input::-moz-focus-inner, input::-moz-focus-outer {
 
   .navbar .site-menu {
     display: none;
+  }
+
+  .accreditation-strip {
+    justify-content: center;
+    padding: 24px;
+  }
+
+  .accreditation-badge {
+    flex: 1 1 calc(50% - 30px);
+    max-width: 320px;
   }
 
   .navbar .navbar-button span {
@@ -3737,6 +3798,22 @@ input::-moz-focus-inner, input::-moz-focus-outer {
   .icon-content {
     width: 100%;
     margin: 15px 0;
+  }
+
+  .accreditation-strip {
+    padding: 22px;
+    gap: 18px;
+  }
+
+  .accreditation-badge {
+    flex: 1 1 100%;
+    justify-content: center;
+    text-align: center;
+  }
+
+  .accreditation-badge span {
+    font-size: 12px;
+    letter-spacing: 0.5px;
   }
 
   .icon-content small {

--- a/images/badge-capeb.svg
+++ b/images/badge-capeb.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 120" role="img" aria-labelledby="title desc">
+  <title id="title">CAPEB artisans du bâtiment</title>
+  <desc id="desc">Stylised badge highlighting the CAPEB federation</desc>
+  <rect x="5" y="5" width="170" height="110" rx="14" fill="#b80f2e"/>
+  <path d="M37 38h46l20 20-20 20H37z" fill="#ffffff" opacity="0.92"/>
+  <path d="M92 28h20l31 31-31 31H92l31-31z" fill="#ff7a04"/>
+  <text x="50%" y="96" fill="#ffffff" font-size="18" font-family="'Arial Black', 'Museo Sans', sans-serif" font-weight="700" text-anchor="middle">CAPEB</text>
+</svg>

--- a/images/badge-eco-artisan.svg
+++ b/images/badge-eco-artisan.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 120" role="img" aria-labelledby="title desc">
+  <title id="title">Éco Artisan efficacité énergétique</title>
+  <desc id="desc">Stylised badge referencing the Éco Artisan label</desc>
+  <rect x="5" y="5" width="170" height="110" rx="14" fill="#0b8643"/>
+  <circle cx="60" cy="60" r="26" fill="#feed01"/>
+  <path d="M86 40h54l-10 18 10 18H94l-8-14z" fill="#ffffff" opacity="0.9"/>
+  <text x="50%" y="94" fill="#ffffff" font-size="16" font-family="'Arial Black', 'Museo Sans', sans-serif" font-weight="700" text-anchor="middle">ÉCO ARTISAN</text>
+</svg>

--- a/images/badge-handibat.svg
+++ b/images/badge-handibat.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 120" role="img" aria-labelledby="title desc">
+  <title id="title">Handibat accessibilité</title>
+  <desc id="desc">Stylised badge for Handibat accessibility accreditation</desc>
+  <rect x="5" y="5" width="170" height="110" rx="14" fill="#005aa7"/>
+  <rect x="18" y="18" width="144" height="84" rx="12" fill="#ffffff"/>
+  <path d="M60 40a12 12 0 1 1 12 12 12 12 0 0 1-12-12zm38 0h36v8h-22l4 16h18v8H94.5l-4.5-16H80v-8h7.5z" fill="#005aa7"/>
+  <text x="50%" y="92" fill="#005aa7" font-size="16" font-family="'Arial Black', 'Museo Sans', sans-serif" font-weight="700" text-anchor="middle">HANDIBAT</text>
+</svg>

--- a/images/badge-rge.svg
+++ b/images/badge-rge.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 120" role="img" aria-labelledby="title desc">
+  <title id="title">RGE Qualibat certification</title>
+  <desc id="desc">Stylised badge representing the RGE Qualibat accreditation</desc>
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#512d9d"/>
+      <stop offset="100%" stop-color="#714ac7"/>
+    </linearGradient>
+  </defs>
+  <rect x="5" y="5" width="170" height="110" rx="14" fill="url(#grad)"/>
+  <polygon points="90,22 140,82 40,82" fill="#feed01" opacity="0.92"/>
+  <text x="50%" y="48%" fill="#ffffff" font-size="22" font-family="'Arial Black', 'Museo Sans', sans-serif" font-weight="700" text-anchor="middle">RGE</text>
+  <text x="50%" y="70%" fill="#ffffff" font-size="14" font-family="'Arial', 'Museo Sans', sans-serif" text-anchor="middle" letter-spacing="2">QUALIBAT</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -287,6 +287,33 @@
       <div class="header-box"> <b>+10</b> <small>ANNÉES D’EXPÉRIENCE</small> </div>
     </div>
     <!-- end slider-main -->
+    <div class="accreditation-strip hero-badges" aria-label="Certifications et fédérations professionnelles reconnues">
+      <div class="accreditation-badge">
+        <figure>
+          <img src="images/badge-rge.svg" alt="Label RGE Qualibat détenu par RenoGo">
+        </figure>
+        <span>Travaux RGE Qualibat</span>
+      </div>
+      <div class="accreditation-badge">
+        <figure>
+          <img src="images/badge-handibat.svg" alt="Certification d’accessibilité Handibat">
+        </figure>
+        <span>Accessibilité Handibat</span>
+      </div>
+      <div class="accreditation-badge">
+        <figure>
+          <img src="images/badge-capeb.svg" alt="Adhésion CAPEB — artisans du bâtiment">
+        </figure>
+        <span>Réseau CAPEB</span>
+      </div>
+      <div class="accreditation-badge">
+        <figure>
+          <img src="images/badge-eco-artisan.svg" alt="Mention Éco Artisan pour la performance énergétique">
+        </figure>
+        <span>Mention Éco Artisan</span>
+      </div>
+    </div>
+    <!-- end accreditation-strip -->
   </div>
 </header>
 <!-- end slider -->
@@ -325,6 +352,32 @@
         </div>
       </div>
 
+    </div>
+    <div class="accreditation-strip" aria-label="Certifications RenoGo au service de vos projets">
+      <div class="accreditation-badge">
+        <figure>
+          <img src="images/badge-rge.svg" alt="Label RGE Qualibat détenu par RenoGo">
+        </figure>
+        <span>Qualibat rénovation globale</span>
+      </div>
+      <div class="accreditation-badge">
+        <figure>
+          <img src="images/badge-handibat.svg" alt="Certification d’accessibilité Handibat">
+        </figure>
+        <span>Solutions Handibat</span>
+      </div>
+      <div class="accreditation-badge">
+        <figure>
+          <img src="images/badge-capeb.svg" alt="Adhésion CAPEB — artisans du bâtiment">
+        </figure>
+        <span>Artisans CAPEB</span>
+      </div>
+      <div class="accreditation-badge">
+        <figure>
+          <img src="images/badge-eco-artisan.svg" alt="Mention Éco Artisan pour la performance énergétique">
+        </figure>
+        <span>Performance Éco Artisan</span>
+      </div>
     </div>
   </div>
 </section>

--- a/projects.html
+++ b/projects.html
@@ -246,6 +246,37 @@
   </header>
   <!-- end page-header -->
 
+  <section class="content-section accreditation-wrapper">
+    <div class="container">
+      <div class="accreditation-strip" aria-label="Labels et fédérations qui accompagnent nos projets">
+        <div class="accreditation-badge">
+          <figure>
+            <img src="images/badge-rge.svg" alt="Label RGE Qualibat détenu par RenoGo">
+          </figure>
+          <span>Chantiers RGE Qualibat</span>
+        </div>
+        <div class="accreditation-badge">
+          <figure>
+            <img src="images/badge-handibat.svg" alt="Certification d’accessibilité Handibat">
+          </figure>
+          <span>Accessibilité Handibat</span>
+        </div>
+        <div class="accreditation-badge">
+          <figure>
+            <img src="images/badge-capeb.svg" alt="Adhésion CAPEB — artisans du bâtiment">
+          </figure>
+          <span>Artisans CAPEB</span>
+        </div>
+        <div class="accreditation-badge">
+          <figure>
+            <img src="images/badge-eco-artisan.svg" alt="Mention Éco Artisan pour la performance énergétique">
+          </figure>
+          <span>Performance Éco Artisan</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
   <section class="content-section">
     <div class="container">
       <div class="row align-items-center mb-5">

--- a/services.html
+++ b/services.html
@@ -244,6 +244,36 @@
   <!-- end container -->
 </header>
 <!-- end page-header -->
+<section class="content-section accreditation-wrapper">
+  <div class="container">
+    <div class="accreditation-strip" aria-label="Labels qualité RenoGo">
+      <div class="accreditation-badge">
+        <figure>
+          <img src="images/badge-rge.svg" alt="Label RGE Qualibat détenu par RenoGo">
+        </figure>
+        <span>Rénovation RGE Qualibat</span>
+      </div>
+      <div class="accreditation-badge">
+        <figure>
+          <img src="images/badge-handibat.svg" alt="Certification d’accessibilité Handibat">
+        </figure>
+        <span>Conception Handibat</span>
+      </div>
+      <div class="accreditation-badge">
+        <figure>
+          <img src="images/badge-capeb.svg" alt="Adhésion CAPEB — artisans du bâtiment">
+        </figure>
+        <span>Partenaire CAPEB</span>
+      </div>
+      <div class="accreditation-badge">
+        <figure>
+          <img src="images/badge-eco-artisan.svg" alt="Mention Éco Artisan pour la performance énergétique">
+        </figure>
+        <span>Performance Éco Artisan</span>
+      </div>
+    </div>
+  </div>
+</section>
 <section class="content-section">
   <div class="container">
     <div class="row">


### PR DESCRIPTION
## Summary
- add reusable accreditation badge strip beside the homepage hero and services highlights
- surface the badge strip on services, projects, and contact pages for consistent trust messaging
- introduce svg badge assets and styling to keep logos responsive across breakpoints

## Testing
- not run (static assets)


------
https://chatgpt.com/codex/tasks/task_e_68e291bfa814832eb40f4387be45f3ec