### PR TITLE
Rollback site to October 3 snapshot

### DIFF
--- a/about-company.html
+++ b/about-company.html
@@ -187,20 +187,6 @@
           <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
-      <div class="contact-info contact-info--drawer" role="region" aria-label="Informations de contact RenoGo">
-        <div class="contact-info__item">
-          <i class="lni lni-timer" aria-hidden="true"></i>
-          <span>Du lundi au vendredi : 8h30 – 18h30</span>
-        </div>
-        <div class="contact-info__item">
-          <i class="lni lni-warning" aria-hidden="true"></i>
-          <span>Assistance d'urgence 24/7 pour nos clients</span>
-        </div>
-        <a href="tel:+33123456789" class="contact-info__item contact-info__link" aria-label="Appeler RenoGo au +33 1 23 45 67 89">
-          <i class="lni lni-phone" aria-hidden="true"></i>
-          <span>+33 1 23 45 67 89</span>
-        </a>
-      </div>
     </div>
     <!-- end show-mobile -->
 
@@ -211,22 +197,6 @@
 <!-- end side-widget -->
 
 
-<div class="top-bar" role="region" aria-label="Informations de contact RenoGo">
-  <div class="container contact-info">
-    <div class="contact-info__item">
-      <i class="lni lni-timer" aria-hidden="true"></i>
-      <span>Du lundi au vendredi : 8h30 – 18h30</span>
-    </div>
-    <div class="contact-info__item">
-      <i class="lni lni-warning" aria-hidden="true"></i>
-      <span>Assistance d'urgence 24/7 pour nos clients</span>
-    </div>
-    <a href="tel:+33123456789" class="contact-info__item contact-info__link" aria-label="Appeler RenoGo au +33 1 23 45 67 89">
-      <i class="lni lni-phone" aria-hidden="true"></i>
-      <span>+33 1 23 45 67 89</span>
-    </a>
-  </div>
-</div>
 <!-- ===== NAVBAR (desktop / tablet) ===== -->
 <nav class="navbar">
   <div class="container">

--- a/certificates.html
+++ b/certificates.html
@@ -104,44 +104,13 @@
       </ul>
     </div>
     <!-- end site-menu -->
-			
-      <div class="contact-info contact-info--drawer" role="region" aria-label="Informations de contact RenoGo">
-        <div class="contact-info__item">
-          <i class="lni lni-timer" aria-hidden="true"></i>
-          <span>Du lundi au vendredi : 8h30 – 18h30</span>
-        </div>
-        <div class="contact-info__item">
-          <i class="lni lni-warning" aria-hidden="true"></i>
-          <span>Assistance d'urgence 24/7 pour nos clients</span>
-        </div>
-        <a href="tel:+33123456789" class="contact-info__item contact-info__link" aria-label="Appeler RenoGo au +33 1 23 45 67 89">
-          <i class="lni lni-phone" aria-hidden="true"></i>
-          <span>+33 1 23 45 67 89</span>
-        </a>
-      </div>
-    </div>
+			</div>
 		<!-- end show-mobile -->
 		<small>© 2020 Consto | Industrial Construction Company</small>
 		</div>
 		<!-- end inner -->
 	</aside>
 	<!-- end side-widget -->
-<div class="top-bar" role="region" aria-label="Informations de contact RenoGo">
-  <div class="container contact-info">
-    <div class="contact-info__item">
-      <i class="lni lni-timer" aria-hidden="true"></i>
-      <span>Du lundi au vendredi : 8h30 – 18h30</span>
-    </div>
-    <div class="contact-info__item">
-      <i class="lni lni-warning" aria-hidden="true"></i>
-      <span>Assistance d'urgence 24/7 pour nos clients</span>
-    </div>
-    <a href="tel:+33123456789" class="contact-info__item contact-info__link" aria-label="Appeler RenoGo au +33 1 23 45 67 89">
-      <i class="lni lni-phone" aria-hidden="true"></i>
-      <span>+33 1 23 45 67 89</span>
-    </a>
-  </div>
-</div>
 <nav class="navbar">
   <div class="container">
     <div class="logo"> <a href="index.html"><img src="images/logo.png" alt="Image"></a> </div>

--- a/contact.html
+++ b/contact.html
@@ -187,20 +187,6 @@
           <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
-      <div class="contact-info contact-info--drawer" role="region" aria-label="Informations de contact RenoGo">
-        <div class="contact-info__item">
-          <i class="lni lni-timer" aria-hidden="true"></i>
-          <span>Du lundi au vendredi : 8h30 – 18h30</span>
-        </div>
-        <div class="contact-info__item">
-          <i class="lni lni-warning" aria-hidden="true"></i>
-          <span>Assistance d'urgence 24/7 pour nos clients</span>
-        </div>
-        <a href="tel:+33123456789" class="contact-info__item contact-info__link" aria-label="Appeler RenoGo au +33 1 23 45 67 89">
-          <i class="lni lni-phone" aria-hidden="true"></i>
-          <span>+33 1 23 45 67 89</span>
-        </a>
-      </div>
     </div>
     <!-- end show-mobile -->
 
@@ -211,22 +197,6 @@
 <!-- end side-widget -->
 
 
-<div class="top-bar" role="region" aria-label="Informations de contact RenoGo">
-  <div class="container contact-info">
-    <div class="contact-info__item">
-      <i class="lni lni-timer" aria-hidden="true"></i>
-      <span>Du lundi au vendredi : 8h30 – 18h30</span>
-    </div>
-    <div class="contact-info__item">
-      <i class="lni lni-warning" aria-hidden="true"></i>
-      <span>Assistance d'urgence 24/7 pour nos clients</span>
-    </div>
-    <a href="tel:+33123456789" class="contact-info__item contact-info__link" aria-label="Appeler RenoGo au +33 1 23 45 67 89">
-      <i class="lni lni-phone" aria-hidden="true"></i>
-      <span>+33 1 23 45 67 89</span>
-    </a>
-  </div>
-</div>
 <!-- ===== NAVBAR (desktop / tablet) ===== -->
 <nav class="navbar">
   <div class="container">
@@ -274,36 +244,6 @@
   <!-- end container -->
 </header>
 <!-- end page-header -->
-<section class="content-section accreditation-wrapper">
-  <div class="container">
-    <div class="accreditation-strip" aria-label="Garanties et certifications RenoGo">
-      <div class="accreditation-badge">
-        <figure>
-          <img src="images/badge-rge.svg" alt="Label RGE Qualibat détenu par RenoGo">
-        </figure>
-        <span>Expertise RGE Qualibat</span>
-      </div>
-      <div class="accreditation-badge">
-        <figure>
-          <img src="images/badge-handibat.svg" alt="Certification d’accessibilité Handibat">
-        </figure>
-        <span>Accessibilité Handibat</span>
-      </div>
-      <div class="accreditation-badge">
-        <figure>
-          <img src="images/badge-capeb.svg" alt="Adhésion CAPEB — artisans du bâtiment">
-        </figure>
-        <span>Réseau CAPEB</span>
-      </div>
-      <div class="accreditation-badge">
-        <figure>
-          <img src="images/badge-eco-artisan.svg" alt="Mention Éco Artisan pour la performance énergétique">
-        </figure>
-        <span>Performance Éco Artisan</span>
-      </div>
-    </div>
-  </div>
-</section>
 <section class="content-section">
   <div class="container">
     <div class="row">

--- a/core-values.html
+++ b/core-values.html
@@ -104,44 +104,13 @@
       </ul>
     </div>
     <!-- end site-menu -->
-			
-      <div class="contact-info contact-info--drawer" role="region" aria-label="Informations de contact RenoGo">
-        <div class="contact-info__item">
-          <i class="lni lni-timer" aria-hidden="true"></i>
-          <span>Du lundi au vendredi : 8h30 – 18h30</span>
-        </div>
-        <div class="contact-info__item">
-          <i class="lni lni-warning" aria-hidden="true"></i>
-          <span>Assistance d'urgence 24/7 pour nos clients</span>
-        </div>
-        <a href="tel:+33123456789" class="contact-info__item contact-info__link" aria-label="Appeler RenoGo au +33 1 23 45 67 89">
-          <i class="lni lni-phone" aria-hidden="true"></i>
-          <span>+33 1 23 45 67 89</span>
-        </a>
-      </div>
-    </div>
+			</div>
 		<!-- end show-mobile -->
 		<small>© 2020 Consto | Industrial Construction Company</small>
 		</div>
 		<!-- end inner -->
 	</aside>
 	<!-- end side-widget -->
-<div class="top-bar" role="region" aria-label="Informations de contact RenoGo">
-  <div class="container contact-info">
-    <div class="contact-info__item">
-      <i class="lni lni-timer" aria-hidden="true"></i>
-      <span>Du lundi au vendredi : 8h30 – 18h30</span>
-    </div>
-    <div class="contact-info__item">
-      <i class="lni lni-warning" aria-hidden="true"></i>
-      <span>Assistance d'urgence 24/7 pour nos clients</span>
-    </div>
-    <a href="tel:+33123456789" class="contact-info__item contact-info__link" aria-label="Appeler RenoGo au +33 1 23 45 67 89">
-      <i class="lni lni-phone" aria-hidden="true"></i>
-      <span>+33 1 23 45 67 89</span>
-    </a>
-  </div>
-</div>
 <nav class="navbar">
   <div class="container">
     <div class="logo"> <a href="index.html"><img src="images/logo.png" alt="Image"></a> </div>

--- a/css/style.css
+++ b/css/style.css
@@ -672,81 +672,6 @@ a:hover {
   width: 100%;
 }
 
-/* TOP BAR */
-.top-bar {
-  width: 100%;
-  position: fixed;
-  left: 0;
-  top: 0;
-  z-index: 5;
-  background: #ff7a04;
-  color: #0b0b0b;
-  font-size: 13px;
-  line-height: 1.4;
-  padding: 10px 0;
-  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.08);
-}
-.top-bar .contact-info {
-  width: 100%;
-  justify-content: space-between;
-}
-.contact-info {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 18px;
-}
-.contact-info__item {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-}
-.contact-info i {
-  font-size: 16px;
-}
-.contact-info__link {
-  font-weight: 700;
-  text-decoration: none;
-}
-.contact-info__link:hover,
-.contact-info__link:focus {
-  text-decoration: none;
-}
-.contact-info__link:focus-visible {
-  outline: 2px solid #0b0b0b;
-  outline-offset: 2px;
-}
-.top-bar .contact-info__item,
-.top-bar .contact-info__link {
-  color: #0b0b0b;
-}
-.top-bar .contact-info__link {
-  white-space: nowrap;
-}
-.top-bar .contact-info i {
-  color: #0b0b0b;
-}
-.contact-info--drawer {
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 12px;
-  margin-top: 20px;
-  padding-top: 20px;
-  border-top: 1px solid rgba(255, 255, 255, 0.2);
-  color: #fff;
-}
-.contact-info--drawer .contact-info__link {
-  color: #ff7a04;
-}
-.contact-info--drawer i {
-  color: #ff7a04;
-}
-.top-bar + .navbar {
-  --navbar-offset: 70px;
-}
-
 /* NAVBAR */
 .navbar {
   width: 100%;
@@ -755,7 +680,7 @@ a:hover {
   padding: 20px 0;
   position: fixed;
   left: 0;
-  top: var(--navbar-offset, 0);
+  top: 0;
   z-index: 4;
   transition: top ease 1s;
 }
@@ -763,7 +688,7 @@ a:hover {
   background: #0b0b0b;
 }
 .navbar.nav-down {
-  top: var(--navbar-offset, 0);
+  top: 0;
 }
 .navbar.nav-up {
   top: -100%;
@@ -1092,48 +1017,6 @@ a:hover {
 }
 .slider .slider-content .controls .button-next:hover {
   background: #ff7a04;
-}
-
-/* ACCREDITATION STRIP */
-.accreditation-strip {
-  width: 100%;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 30px;
-  padding: 26px 36px;
-  border: 2px solid #e8e8e8;
-  border-radius: 24px;
-  background: #ffffff;
-}
-
-.accreditation-badge {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-}
-
-.accreditation-badge figure {
-  margin: 0;
-  width: 92px;
-}
-
-.accreditation-badge figure img {
-  display: block;
-  width: 100%;
-  height: auto;
-}
-
-.accreditation-badge span {
-  font-size: 13px;
-  font-weight: 600;
-  letter-spacing: 1px;
-  text-transform: uppercase;
-}
-
-.hero-badges {
-  margin-top: 60px;
-  background: rgba(255, 255, 255, 0.9);
 }
 .slider .slider-main {
   width: calc(50vw + 80px);
@@ -3558,14 +3441,6 @@ input::-moz-focus-inner, input::-moz-focus-outer {
 
 /* RESPONSIVE MEDIUM  */
 @media only screen and (max-width: 1199px), only screen and (max-device-width: 1199px) {
-  .top-bar .contact-info {
-    gap: 14px;
-  }
-
-  .top-bar + .navbar {
-    --navbar-offset: 80px;
-  }
-
   .navbar .navbar-button {
     padding: 0 15px;
     margin-left: 20px;
@@ -3602,36 +3477,9 @@ input::-moz-focus-inner, input::-moz-focus-outer {
   .footer-bar h2 {
     padding: 0;
   }
-
-  .accreditation-strip {
-    gap: 24px;
-    padding: 24px 28px;
-  }
-
-  .accreditation-badge {
-    flex: 1 1 calc(50% - 24px);
-  }
 }
 /* RESPONSIVE TABLET  */
 @media only screen and (max-width: 991px), only screen and (max-device-width: 991px) {
-  .top-bar {
-    padding: 14px 0;
-  }
-
-  .top-bar .contact-info {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 12px;
-  }
-
-  .top-bar + .navbar {
-    --navbar-offset: 112px;
-  }
-
-  .contact-info--drawer {
-    gap: 16px;
-  }
-
   .side-widget {
     box-shadow: none;
   }
@@ -3706,16 +3554,6 @@ input::-moz-focus-inner, input::-moz-focus-outer {
 
   .navbar .site-menu {
     display: none;
-  }
-
-  .accreditation-strip {
-    justify-content: center;
-    padding: 24px;
-  }
-
-  .accreditation-badge {
-    flex: 1 1 calc(50% - 30px);
-    max-width: 320px;
   }
 
   .navbar .navbar-button span {
@@ -3836,14 +3674,6 @@ input::-moz-focus-inner, input::-moz-focus-outer {
 }
 /* RESPONSIVE MOBILE */
 @media only screen and (max-width: 767px), only screen and (max-device-width: 767px) {
-  .top-bar + .navbar {
-    --navbar-offset: 140px;
-  }
-
-  .contact-info--drawer {
-    gap: 18px;
-  }
-
   .side-widget {
     width: 240px;
   }
@@ -3907,22 +3737,6 @@ input::-moz-focus-inner, input::-moz-focus-outer {
   .icon-content {
     width: 100%;
     margin: 15px 0;
-  }
-
-  .accreditation-strip {
-    padding: 22px;
-    gap: 18px;
-  }
-
-  .accreditation-badge {
-    flex: 1 1 100%;
-    justify-content: center;
-    text-align: center;
-  }
-
-  .accreditation-badge span {
-    font-size: 12px;
-    letter-spacing: 0.5px;
   }
 
   .icon-content small {

--- a/index.html
+++ b/index.html
@@ -187,20 +187,6 @@
           <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
-      <div class="contact-info contact-info--drawer" role="region" aria-label="Informations de contact RenoGo">
-        <div class="contact-info__item">
-          <i class="lni lni-timer" aria-hidden="true"></i>
-          <span>Du lundi au vendredi : 8h30 – 18h30</span>
-        </div>
-        <div class="contact-info__item">
-          <i class="lni lni-warning" aria-hidden="true"></i>
-          <span>Assistance d'urgence 24/7 pour nos clients</span>
-        </div>
-        <a href="tel:+33123456789" class="contact-info__item contact-info__link" aria-label="Appeler RenoGo au +33 1 23 45 67 89">
-          <i class="lni lni-phone" aria-hidden="true"></i>
-          <span>+33 1 23 45 67 89</span>
-        </a>
-      </div>
     </div>
     <!-- end show-mobile -->
 
@@ -211,22 +197,6 @@
 <!-- end side-widget -->
 
 
-<div class="top-bar" role="region" aria-label="Informations de contact RenoGo">
-  <div class="container contact-info">
-    <div class="contact-info__item">
-      <i class="lni lni-timer" aria-hidden="true"></i>
-      <span>Du lundi au vendredi : 8h30 – 18h30</span>
-    </div>
-    <div class="contact-info__item">
-      <i class="lni lni-warning" aria-hidden="true"></i>
-      <span>Assistance d'urgence 24/7 pour nos clients</span>
-    </div>
-    <a href="tel:+33123456789" class="contact-info__item contact-info__link" aria-label="Appeler RenoGo au +33 1 23 45 67 89">
-      <i class="lni lni-phone" aria-hidden="true"></i>
-      <span>+33 1 23 45 67 89</span>
-    </a>
-  </div>
-</div>
 <!-- ===== NAVBAR (desktop / tablet) ===== -->
 <nav class="navbar">
   <div class="container">
@@ -317,33 +287,6 @@
       <div class="header-box"> <b>+10</b> <small>ANNÉES D’EXPÉRIENCE</small> </div>
     </div>
     <!-- end slider-main -->
-    <div class="accreditation-strip hero-badges" aria-label="Certifications et fédérations professionnelles reconnues">
-      <div class="accreditation-badge">
-        <figure>
-          <img src="images/badge-rge.svg" alt="Label RGE Qualibat détenu par RenoGo">
-        </figure>
-        <span>Travaux RGE Qualibat</span>
-      </div>
-      <div class="accreditation-badge">
-        <figure>
-          <img src="images/badge-handibat.svg" alt="Certification d’accessibilité Handibat">
-        </figure>
-        <span>Accessibilité Handibat</span>
-      </div>
-      <div class="accreditation-badge">
-        <figure>
-          <img src="images/badge-capeb.svg" alt="Adhésion CAPEB — artisans du bâtiment">
-        </figure>
-        <span>Réseau CAPEB</span>
-      </div>
-      <div class="accreditation-badge">
-        <figure>
-          <img src="images/badge-eco-artisan.svg" alt="Mention Éco Artisan pour la performance énergétique">
-        </figure>
-        <span>Mention Éco Artisan</span>
-      </div>
-    </div>
-    <!-- end accreditation-strip -->
   </div>
 </header>
 <!-- end slider -->
@@ -358,7 +301,7 @@
           <figure><img src="images/icon03.png" alt="Experts RenoGo rénovant un appartement en Normandie"></figure>
           <h3>Rénovation</h3>
           <small>Diagnostic technique, optimisation énergétique, suivi de chantier : nous orchestrons des rénovations globales certifiées RGE pour valoriser votre maison ou votre patrimoine locatif.</small>
-          <a href="services.html#renovation-energetique">+</a>
+          <a href="services.html#tab02">+</a>
         </div>
       </div>
 
@@ -368,7 +311,7 @@
           <figure><img src="images/icon05.png" alt="Aménagement intérieur RenoGo optimisant un espace de vie"></figure>
           <h3>Aménagement</h3>
           <small>Cuisines ergonomiques, suites parentales, plateaux bureaux modulaires : nos designers créent des aménagements intelligents qui améliorent le confort et la productivité.</small>
-          <a href="services.html#cuisine-sur-mesure">+</a>
+          <a href="services.html#tab05">+</a>
         </div>
       </div>
 
@@ -378,36 +321,10 @@
           <figure><img src="images/icon06.png" alt="Réaménagement de locaux professionnels par RenoGo"></figure>
           <h3>Locaux Professionnels</h3>
           <small>Bureaux, commerces, cabinets et coworkings : nous intégrons ergonomie, sécurité et branding pour offrir des espaces performants alignés sur vos objectifs business.</small>
-          <a href="services.html#fit-out-tertiaire">+</a>
+          <a href="services.html#services-electricite">+</a>
         </div>
       </div>
 
-    </div>
-    <div class="accreditation-strip" aria-label="Certifications RenoGo au service de vos projets">
-      <div class="accreditation-badge">
-        <figure>
-          <img src="images/badge-rge.svg" alt="Label RGE Qualibat détenu par RenoGo">
-        </figure>
-        <span>Qualibat rénovation globale</span>
-      </div>
-      <div class="accreditation-badge">
-        <figure>
-          <img src="images/badge-handibat.svg" alt="Certification d’accessibilité Handibat">
-        </figure>
-        <span>Solutions Handibat</span>
-      </div>
-      <div class="accreditation-badge">
-        <figure>
-          <img src="images/badge-capeb.svg" alt="Adhésion CAPEB — artisans du bâtiment">
-        </figure>
-        <span>Artisans CAPEB</span>
-      </div>
-      <div class="accreditation-badge">
-        <figure>
-          <img src="images/badge-eco-artisan.svg" alt="Mention Éco Artisan pour la performance énergétique">
-        </figure>
-        <span>Performance Éco Artisan</span>
-      </div>
     </div>
   </div>
 </section>
@@ -571,37 +488,37 @@
       </div>
 
       <div class="col-lg-4 col-md-6">
-        <a href="services.html#renovation-energetique" class="sector-box">
+        <a href="services.html#maisons" class="sector-box">
           <span>Maisons individuelles</span> <i class="lni lni-arrow-right"></i>
         </a>
       </div>
 
       <div class="col-lg-4 col-md-6">
-        <a href="services.html#salle-de-bains-pmr" class="sector-box">
+        <a href="services.html#appartements" class="sector-box">
           <span>Appartements</span> <i class="lni lni-arrow-right"></i>
         </a>
       </div>
 
       <div class="col-lg-4 col-md-6">
-        <a href="services.html#fit-out-tertiaire" class="sector-box">
+        <a href="services.html#bureaux" class="sector-box">
           <span>Bureaux & open spaces</span> <i class="lni lni-arrow-right"></i>
         </a>
       </div>
 
       <div class="col-lg-4 col-md-6">
-        <a href="services.html#fit-out-tertiaire" class="sector-box">
+        <a href="services.html#commerces" class="sector-box">
           <span>Commerces & locaux</span> <i class="lni lni-arrow-right"></i>
         </a>
       </div>
 
       <div class="col-lg-4 col-md-6">
-        <a href="services.html#tab01" class="sector-box">
+        <a href="services.html#jardins" class="sector-box">
           <span>Jardins & espaces verts</span> <i class="lni lni-arrow-right"></i>
         </a>
       </div>
 
       <div class="col-lg-4 col-md-6">
-        <a href="services.html#accompagnement-renogo" class="sector-box">
+        <a href="services.html#coproprietes" class="sector-box">
           <span>Copropriétés & résidences</span> <i class="lni lni-arrow-right"></i>
         </a>
       </div>

--- a/leadership.html
+++ b/leadership.html
@@ -104,44 +104,13 @@
       </ul>
     </div>
     <!-- end site-menu -->
-			
-      <div class="contact-info contact-info--drawer" role="region" aria-label="Informations de contact RenoGo">
-        <div class="contact-info__item">
-          <i class="lni lni-timer" aria-hidden="true"></i>
-          <span>Du lundi au vendredi : 8h30 – 18h30</span>
-        </div>
-        <div class="contact-info__item">
-          <i class="lni lni-warning" aria-hidden="true"></i>
-          <span>Assistance d'urgence 24/7 pour nos clients</span>
-        </div>
-        <a href="tel:+33123456789" class="contact-info__item contact-info__link" aria-label="Appeler RenoGo au +33 1 23 45 67 89">
-          <i class="lni lni-phone" aria-hidden="true"></i>
-          <span>+33 1 23 45 67 89</span>
-        </a>
-      </div>
-    </div>
+			</div>
 		<!-- end show-mobile -->
 		<small>© 2020 Consto | Industrial Construction Company</small>
 		</div>
 		<!-- end inner -->
 	</aside>
 	<!-- end side-widget -->
-<div class="top-bar" role="region" aria-label="Informations de contact RenoGo">
-  <div class="container contact-info">
-    <div class="contact-info__item">
-      <i class="lni lni-timer" aria-hidden="true"></i>
-      <span>Du lundi au vendredi : 8h30 – 18h30</span>
-    </div>
-    <div class="contact-info__item">
-      <i class="lni lni-warning" aria-hidden="true"></i>
-      <span>Assistance d'urgence 24/7 pour nos clients</span>
-    </div>
-    <a href="tel:+33123456789" class="contact-info__item contact-info__link" aria-label="Appeler RenoGo au +33 1 23 45 67 89">
-      <i class="lni lni-phone" aria-hidden="true"></i>
-      <span>+33 1 23 45 67 89</span>
-    </a>
-  </div>
-</div>
 <nav class="navbar">
   <div class="container">
     <div class="logo"> <a href="index.html"><img src="images/logo.png" alt="Image"></a> </div>

--- a/news-sing.html
+++ b/news-sing.html
@@ -104,44 +104,13 @@
       </ul>
     </div>
     <!-- end site-menu -->
-			
-      <div class="contact-info contact-info--drawer" role="region" aria-label="Informations de contact RenoGo">
-        <div class="contact-info__item">
-          <i class="lni lni-timer" aria-hidden="true"></i>
-          <span>Du lundi au vendredi : 8h30 – 18h30</span>
-        </div>
-        <div class="contact-info__item">
-          <i class="lni lni-warning" aria-hidden="true"></i>
-          <span>Assistance d'urgence 24/7 pour nos clients</span>
-        </div>
-        <a href="tel:+33123456789" class="contact-info__item contact-info__link" aria-label="Appeler RenoGo au +33 1 23 45 67 89">
-          <i class="lni lni-phone" aria-hidden="true"></i>
-          <span>+33 1 23 45 67 89</span>
-        </a>
-      </div>
-    </div>
+			</div>
 		<!-- end show-mobile -->
 		<small>© 2020 Consto | Industrial Construction Company</small>
 		</div>
 		<!-- end inner -->
 	</aside>
 	<!-- end side-widget -->
-<div class="top-bar" role="region" aria-label="Informations de contact RenoGo">
-  <div class="container contact-info">
-    <div class="contact-info__item">
-      <i class="lni lni-timer" aria-hidden="true"></i>
-      <span>Du lundi au vendredi : 8h30 – 18h30</span>
-    </div>
-    <div class="contact-info__item">
-      <i class="lni lni-warning" aria-hidden="true"></i>
-      <span>Assistance d'urgence 24/7 pour nos clients</span>
-    </div>
-    <a href="tel:+33123456789" class="contact-info__item contact-info__link" aria-label="Appeler RenoGo au +33 1 23 45 67 89">
-      <i class="lni lni-phone" aria-hidden="true"></i>
-      <span>+33 1 23 45 67 89</span>
-    </a>
-  </div>
-</div>
 <nav class="navbar">
   <div class="container">
     <div class="logo"> <a href="index.html"><img src="images/logo.png" alt="Image"></a> </div>

--- a/news.html
+++ b/news.html
@@ -187,20 +187,6 @@
           <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
-      <div class="contact-info contact-info--drawer" role="region" aria-label="Informations de contact RenoGo">
-        <div class="contact-info__item">
-          <i class="lni lni-timer" aria-hidden="true"></i>
-          <span>Du lundi au vendredi : 8h30 – 18h30</span>
-        </div>
-        <div class="contact-info__item">
-          <i class="lni lni-warning" aria-hidden="true"></i>
-          <span>Assistance d'urgence 24/7 pour nos clients</span>
-        </div>
-        <a href="tel:+33123456789" class="contact-info__item contact-info__link" aria-label="Appeler RenoGo au +33 1 23 45 67 89">
-          <i class="lni lni-phone" aria-hidden="true"></i>
-          <span>+33 1 23 45 67 89</span>
-        </a>
-      </div>
     </div>
     <!-- end show-mobile -->
 
@@ -209,22 +195,6 @@
   <!-- end inner -->
 </aside>
 <!-- end side-widget -->
-<div class="top-bar" role="region" aria-label="Informations de contact RenoGo">
-  <div class="container contact-info">
-    <div class="contact-info__item">
-      <i class="lni lni-timer" aria-hidden="true"></i>
-      <span>Du lundi au vendredi : 8h30 – 18h30</span>
-    </div>
-    <div class="contact-info__item">
-      <i class="lni lni-warning" aria-hidden="true"></i>
-      <span>Assistance d'urgence 24/7 pour nos clients</span>
-    </div>
-    <a href="tel:+33123456789" class="contact-info__item contact-info__link" aria-label="Appeler RenoGo au +33 1 23 45 67 89">
-      <i class="lni lni-phone" aria-hidden="true"></i>
-      <span>+33 1 23 45 67 89</span>
-    </a>
-  </div>
-</div>
 <!-- ===== NAVBAR (desktop / tablet) ===== -->
 <nav class="navbar">
   <div class="container">

--- a/offices.html
+++ b/offices.html
@@ -104,44 +104,13 @@
       </ul>
     </div>
     <!-- end site-menu -->
-			
-      <div class="contact-info contact-info--drawer" role="region" aria-label="Informations de contact RenoGo">
-        <div class="contact-info__item">
-          <i class="lni lni-timer" aria-hidden="true"></i>
-          <span>Du lundi au vendredi : 8h30 – 18h30</span>
-        </div>
-        <div class="contact-info__item">
-          <i class="lni lni-warning" aria-hidden="true"></i>
-          <span>Assistance d'urgence 24/7 pour nos clients</span>
-        </div>
-        <a href="tel:+33123456789" class="contact-info__item contact-info__link" aria-label="Appeler RenoGo au +33 1 23 45 67 89">
-          <i class="lni lni-phone" aria-hidden="true"></i>
-          <span>+33 1 23 45 67 89</span>
-        </a>
-      </div>
-    </div>
+			</div>
 		<!-- end show-mobile -->
 		<small>© 2020 Consto | Industrial Construction Company</small>
 		</div>
 		<!-- end inner -->
 	</aside>
 	<!-- end side-widget -->
-<div class="top-bar" role="region" aria-label="Informations de contact RenoGo">
-  <div class="container contact-info">
-    <div class="contact-info__item">
-      <i class="lni lni-timer" aria-hidden="true"></i>
-      <span>Du lundi au vendredi : 8h30 – 18h30</span>
-    </div>
-    <div class="contact-info__item">
-      <i class="lni lni-warning" aria-hidden="true"></i>
-      <span>Assistance d'urgence 24/7 pour nos clients</span>
-    </div>
-    <a href="tel:+33123456789" class="contact-info__item contact-info__link" aria-label="Appeler RenoGo au +33 1 23 45 67 89">
-      <i class="lni lni-phone" aria-hidden="true"></i>
-      <span>+33 1 23 45 67 89</span>
-    </a>
-  </div>
-</div>
 <nav class="navbar">
   <div class="container">
     <div class="logo"> <a href="index.html"><img src="images/logo.png" alt="Image"></a> </div>

--- a/our-history.html
+++ b/our-history.html
@@ -104,44 +104,13 @@
       </ul>
     </div>
     <!-- end site-menu -->
-			
-      <div class="contact-info contact-info--drawer" role="region" aria-label="Informations de contact RenoGo">
-        <div class="contact-info__item">
-          <i class="lni lni-timer" aria-hidden="true"></i>
-          <span>Du lundi au vendredi : 8h30 – 18h30</span>
-        </div>
-        <div class="contact-info__item">
-          <i class="lni lni-warning" aria-hidden="true"></i>
-          <span>Assistance d'urgence 24/7 pour nos clients</span>
-        </div>
-        <a href="tel:+33123456789" class="contact-info__item contact-info__link" aria-label="Appeler RenoGo au +33 1 23 45 67 89">
-          <i class="lni lni-phone" aria-hidden="true"></i>
-          <span>+33 1 23 45 67 89</span>
-        </a>
-      </div>
-    </div>
+			</div>
 		<!-- end show-mobile -->
 		<small>© 2020 Consto | Industrial Construction Company</small>
 		</div>
 		<!-- end inner -->
 	</aside>
 	<!-- end side-widget -->
-<div class="top-bar" role="region" aria-label="Informations de contact RenoGo">
-  <div class="container contact-info">
-    <div class="contact-info__item">
-      <i class="lni lni-timer" aria-hidden="true"></i>
-      <span>Du lundi au vendredi : 8h30 – 18h30</span>
-    </div>
-    <div class="contact-info__item">
-      <i class="lni lni-warning" aria-hidden="true"></i>
-      <span>Assistance d'urgence 24/7 pour nos clients</span>
-    </div>
-    <a href="tel:+33123456789" class="contact-info__item contact-info__link" aria-label="Appeler RenoGo au +33 1 23 45 67 89">
-      <i class="lni lni-phone" aria-hidden="true"></i>
-      <span>+33 1 23 45 67 89</span>
-    </a>
-  </div>
-</div>
 <nav class="navbar">
   <div class="container">
     <div class="logo"> <a href="index.html"><img src="images/logo.png" alt="Image"></a> </div>

--- a/project-single.html
+++ b/project-single.html
@@ -104,44 +104,13 @@
       </ul>
     </div>
     <!-- end site-menu -->
-			
-      <div class="contact-info contact-info--drawer" role="region" aria-label="Informations de contact RenoGo">
-        <div class="contact-info__item">
-          <i class="lni lni-timer" aria-hidden="true"></i>
-          <span>Du lundi au vendredi : 8h30 – 18h30</span>
-        </div>
-        <div class="contact-info__item">
-          <i class="lni lni-warning" aria-hidden="true"></i>
-          <span>Assistance d'urgence 24/7 pour nos clients</span>
-        </div>
-        <a href="tel:+33123456789" class="contact-info__item contact-info__link" aria-label="Appeler RenoGo au +33 1 23 45 67 89">
-          <i class="lni lni-phone" aria-hidden="true"></i>
-          <span>+33 1 23 45 67 89</span>
-        </a>
-      </div>
-    </div>
+			</div>
 		<!-- end show-mobile -->
 		<small>© 2020 Consto | Industrial Construction Company</small>
 		</div>
 		<!-- end inner -->
 	</aside>
 	<!-- end side-widget -->
-<div class="top-bar" role="region" aria-label="Informations de contact RenoGo">
-  <div class="container contact-info">
-    <div class="contact-info__item">
-      <i class="lni lni-timer" aria-hidden="true"></i>
-      <span>Du lundi au vendredi : 8h30 – 18h30</span>
-    </div>
-    <div class="contact-info__item">
-      <i class="lni lni-warning" aria-hidden="true"></i>
-      <span>Assistance d'urgence 24/7 pour nos clients</span>
-    </div>
-    <a href="tel:+33123456789" class="contact-info__item contact-info__link" aria-label="Appeler RenoGo au +33 1 23 45 67 89">
-      <i class="lni lni-phone" aria-hidden="true"></i>
-      <span>+33 1 23 45 67 89</span>
-    </a>
-  </div>
-</div>
 <nav class="navbar">
   <div class="container">
     <div class="logo"> <a href="index.html"><img src="images/logo.png" alt="Image"></a> </div>

--- a/projects.html
+++ b/projects.html
@@ -187,20 +187,6 @@
           <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
-      <div class="contact-info contact-info--drawer" role="region" aria-label="Informations de contact RenoGo">
-        <div class="contact-info__item">
-          <i class="lni lni-timer" aria-hidden="true"></i>
-          <span>Du lundi au vendredi : 8h30 – 18h30</span>
-        </div>
-        <div class="contact-info__item">
-          <i class="lni lni-warning" aria-hidden="true"></i>
-          <span>Assistance d'urgence 24/7 pour nos clients</span>
-        </div>
-        <a href="tel:+33123456789" class="contact-info__item contact-info__link" aria-label="Appeler RenoGo au +33 1 23 45 67 89">
-          <i class="lni lni-phone" aria-hidden="true"></i>
-          <span>+33 1 23 45 67 89</span>
-        </a>
-      </div>
     </div>
     <!-- end show-mobile -->
 
@@ -211,22 +197,6 @@
 <!-- end side-widget -->
 
 
-<div class="top-bar" role="region" aria-label="Informations de contact RenoGo">
-  <div class="container contact-info">
-    <div class="contact-info__item">
-      <i class="lni lni-timer" aria-hidden="true"></i>
-      <span>Du lundi au vendredi : 8h30 – 18h30</span>
-    </div>
-    <div class="contact-info__item">
-      <i class="lni lni-warning" aria-hidden="true"></i>
-      <span>Assistance d'urgence 24/7 pour nos clients</span>
-    </div>
-    <a href="tel:+33123456789" class="contact-info__item contact-info__link" aria-label="Appeler RenoGo au +33 1 23 45 67 89">
-      <i class="lni lni-phone" aria-hidden="true"></i>
-      <span>+33 1 23 45 67 89</span>
-    </a>
-  </div>
-</div>
 <!-- ===== NAVBAR (desktop / tablet) ===== -->
 <nav class="navbar">
   <div class="container">
@@ -275,37 +245,6 @@
     <!-- end container -->
   </header>
   <!-- end page-header -->
-
-  <section class="content-section accreditation-wrapper">
-    <div class="container">
-      <div class="accreditation-strip" aria-label="Labels et fédérations qui accompagnent nos projets">
-        <div class="accreditation-badge">
-          <figure>
-            <img src="images/badge-rge.svg" alt="Label RGE Qualibat détenu par RenoGo">
-          </figure>
-          <span>Chantiers RGE Qualibat</span>
-        </div>
-        <div class="accreditation-badge">
-          <figure>
-            <img src="images/badge-handibat.svg" alt="Certification d’accessibilité Handibat">
-          </figure>
-          <span>Accessibilité Handibat</span>
-        </div>
-        <div class="accreditation-badge">
-          <figure>
-            <img src="images/badge-capeb.svg" alt="Adhésion CAPEB — artisans du bâtiment">
-          </figure>
-          <span>Artisans CAPEB</span>
-        </div>
-        <div class="accreditation-badge">
-          <figure>
-            <img src="images/badge-eco-artisan.svg" alt="Mention Éco Artisan pour la performance énergétique">
-          </figure>
-          <span>Performance Éco Artisan</span>
-        </div>
-      </div>
-    </div>
-  </section>
 
   <section class="content-section">
     <div class="container">

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -301,37 +301,16 @@ a:hover{text-decoration: underline; color:$color-dark;}
   to {right: -100%;}
 }
 .page-transition{width: 0; height: 100%; position: fixed; z-index: 9; left: 0; top:0; background: $color-main; transition: all ease 1s;
-        &.active{width: 100%;}}
-
-
-
-
-/* TOP BAR */
-.top-bar{width: 100%; position: fixed; left: 0; top: 0; z-index: 5; background: #ff7a04; color: $color-dark; font-size: 13px; line-height: 1.4; padding: 10px 0; box-shadow: 0 12px 30px rgba(0,0,0,0.08);
-        .contact-info{width: 100%; justify-content: space-between;}}
-.contact-info{display: flex; flex-wrap: wrap; align-items: center; gap: 18px;
-        &__item{display: inline-flex; align-items: center; gap: 8px;}
-        i{font-size: 16px;}
-        &__link{font-weight: 700; text-decoration: none;
-                &:hover{ text-decoration: none;}
-                &:focus{ text-decoration: none;}
-                &:focus-visible{outline: 2px solid $color-dark; outline-offset: 2px;}}}
-.top-bar .contact-info__item,.top-bar .contact-info__link{color: $color-dark;}
-.top-bar .contact-info__link{white-space: nowrap;}
-.top-bar .contact-info i{color: $color-dark;}
-.contact-info--drawer{width: 100%; display: flex; flex-direction: column; align-items: flex-start; gap: 12px; margin-top: 20px; padding-top: 20px; border-top: 1px solid rgba(255,255,255,0.2); color: #fff;
-        .contact-info__link{color: #ff7a04;}
-        i{color: #ff7a04;}}
-.top-bar + .navbar{--navbar-offset: 70px;}
+	&.active{width: 100%;}}
 
 
 
 
 /* NAVBAR */
-.navbar{width: 100%; display: flex; flex-wrap: wrap; padding: 20px 0; position: fixed; left: 0; top: var(--navbar-offset, 0); z-index: 4; transition: top ease 1s;
-        &.sticky{background: $color-dark;}
-        &.nav-down{ top: var(--navbar-offset, 0);}
-        &.nav-up{ top: -100%;}
+.navbar{width: 100%; display: flex; flex-wrap: wrap; padding: 20px 0; position: fixed; left: 0; top: 0; z-index: 4; transition: top ease 1s;
+	&.sticky{background: $color-dark;}
+	&.nav-down{ top: 0;}
+	&.nav-up{ top: -100%;}
 	.logo{ margin-left:0;
 		a{display: block; margin: 0;
 			img{height: 40px;}}}
@@ -924,9 +903,7 @@ input::-moz-focus-inner, input::-moz-focus-outer {  border: 0;}
 
 /* RESPONSIVE MEDIUM  */
 @media only screen and (max-width: 1199px), only screen and (max-device-width: 1199px) {
-        .top-bar .contact-info{gap: 14px;}
-        .top-bar + .navbar{--navbar-offset: 80px;}
-        .navbar .navbar-button {padding: 0 15px; margin-left: 20px;}
+	.navbar .navbar-button {padding: 0 15px; margin-left: 20px;}
 	.navbar .navbar-button i{margin: 0;}
 	.navbar .navbar-button span{display: none;}
 	.slider .slider-content .inner h2{font-size: 50px;}
@@ -940,11 +917,7 @@ input::-moz-focus-inner, input::-moz-focus-outer {  border: 0;}
 
 /* RESPONSIVE TABLET  */
 @media only screen and (max-width: 991px), only screen and (max-device-width: 991px) {
-        .top-bar{padding: 14px 0;}
-        .top-bar .contact-info{flex-direction: column; align-items: flex-start; gap: 12px;}
-        .top-bar + .navbar{--navbar-offset: 112px;}
-        .contact-info--drawer{gap: 16px;}
-        .side-widget{box-shadow: none;}
+	.side-widget{box-shadow: none;}
 	.side-widget .show-mobile{display: block;}
 	.side-widget .hide-mobile{display: none;}
 	.contact-box{margin: 15px 0;}
@@ -991,9 +964,7 @@ input::-moz-focus-inner, input::-moz-focus-outer {  border: 0;}
 
 /* RESPONSIVE MOBILE */
 @media only screen and (max-width: 767px), only screen and (max-device-width: 767px) {
-        .top-bar + .navbar{--navbar-offset: 140px;}
-        .contact-info--drawer{gap: 18px;}
-        .side-widget{width: 240px;}
+	.side-widget{width: 240px;}
 	.search-box .inner{width: 90vw;}
 	.navbar .navbar-button span{display: none;}
 	.navbar .languages{display: none;}

--- a/services.html
+++ b/services.html
@@ -6,8 +6,8 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
   <!-- Primary SEO -->
-  <title>Services RenoGo • Cuisine sur mesure, salles de bains PMR & rénovation globale en Normandie – Île-de-France</title>
-  <meta name="description" content="Découvrez les services RenoGo dédiés à vos projets à forte valeur : cuisine sur mesure, salle de bains & PMR, rénovation énergétique, aménagement tertiaire, maintenance et smart building en Normandie et Île-de-France.">
+  <title>Services RenoGo • Rénovation, efficacité énergétique & maintenance en Normandie – Île-de-France</title>
+  <meta name="description" content="Explorez les services RenoGo : rénovation globale, second œuvre, ingénierie énergétique, aménagement d’espaces, smart building et maintenance immobilière pour particuliers et professionnels.">
   <link rel="canonical" href="https://www.renogo.fr/">
 
   <!-- Indexing -->
@@ -29,8 +29,8 @@
   <meta property="og:locale" content="fr_FR">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="RenoGo">
-  <meta property="og:title" content="Services RenoGo • Cuisine sur mesure, salles de bains PMR & rénovation globale">
-  <meta property="og:description" content="Contractant général en Normandie et Île-de-France pour cuisines sur mesure, salles de bains PMR, rénovation énergétique, fit-out tertiaire et maintenance multitechnique.">
+  <meta property="og:title" content="Services RenoGo • Rénovation & maintenance immobilière">
+  <meta property="og:description" content="Contractant général pour rénovations globales, travaux énergétiques, aménagements de bureaux et entretien multitechnique.">
   <meta property="og:url" content="https://www.renogo.fr/">
   <meta property="og:image" content="https://www.renogo.fr/assets/og/renogo-cover.jpg">
   <meta property="og:image:width" content="1200">
@@ -39,8 +39,8 @@
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@renogo">
-  <meta name="twitter:title" content="Services RenoGo • Cuisine sur mesure, salles de bains PMR & rénovation globale">
-  <meta name="twitter:description" content="Solutions clés en main : cuisines sur mesure, salles de bains accessibles, rénovation énergétique, fit-out tertiaire et maintenance multitechnique.">
+  <meta name="twitter:title" content="Services RenoGo • Rénovation & maintenance immobilière">
+  <meta name="twitter:description" content="Solutions clés en main : rénovation énergétique, design d’intérieur, fit-out tertiaire et contrats de maintenance.">
   <meta name="twitter:image" content="https://www.renogo.fr/assets/og/renogo-cover.jpg">
 
   <!-- Organization -->
@@ -75,7 +75,7 @@
     "url": "https://www.renogo.fr/",
     "logo": "https://www.renogo.fr/assets/logo/renogo-logo.svg",
     "image": "https://www.renogo.fr/assets/og/renogo-cover.jpg",
-    "description": "Rénovation globale, cuisines sur mesure, salles de bains PMR, smart building et maintenance immobilière.",
+    "description": "Rénovation globale, efficacité énergétique, design d’espace, smart building et maintenance immobilière.",
     "telephone": "+33-1-23-45-67-89",
     "areaServed": "FR",
     "priceRange": "€€",
@@ -104,18 +104,6 @@
       "itemOffered": {
         "@type": "Service",
         "name": "Rénovation de cuisine"
-      }
-    },{
-      "@type": "Offer",
-      "itemOffered": {
-        "@type": "Service",
-        "name": "Cuisine sur mesure clé en main"
-      }
-    },{
-      "@type": "Offer",
-      "itemOffered": {
-        "@type": "Service",
-        "name": "Salle de bains & PMR"
       }
     },{
       "@type": "Offer",
@@ -199,20 +187,6 @@
           <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
-      <div class="contact-info contact-info--drawer" role="region" aria-label="Informations de contact RenoGo">
-        <div class="contact-info__item">
-          <i class="lni lni-timer" aria-hidden="true"></i>
-          <span>Du lundi au vendredi : 8h30 – 18h30</span>
-        </div>
-        <div class="contact-info__item">
-          <i class="lni lni-warning" aria-hidden="true"></i>
-          <span>Assistance d'urgence 24/7 pour nos clients</span>
-        </div>
-        <a href="tel:+33123456789" class="contact-info__item contact-info__link" aria-label="Appeler RenoGo au +33 1 23 45 67 89">
-          <i class="lni lni-phone" aria-hidden="true"></i>
-          <span>+33 1 23 45 67 89</span>
-        </a>
-      </div>
     </div>
     <!-- end show-mobile -->
 
@@ -223,22 +197,6 @@
 <!-- end side-widget -->
 
 
-<div class="top-bar" role="region" aria-label="Informations de contact RenoGo">
-  <div class="container contact-info">
-    <div class="contact-info__item">
-      <i class="lni lni-timer" aria-hidden="true"></i>
-      <span>Du lundi au vendredi : 8h30 – 18h30</span>
-    </div>
-    <div class="contact-info__item">
-      <i class="lni lni-warning" aria-hidden="true"></i>
-      <span>Assistance d'urgence 24/7 pour nos clients</span>
-    </div>
-    <a href="tel:+33123456789" class="contact-info__item contact-info__link" aria-label="Appeler RenoGo au +33 1 23 45 67 89">
-      <i class="lni lni-phone" aria-hidden="true"></i>
-      <span>+33 1 23 45 67 89</span>
-    </a>
-  </div>
-</div>
 <!-- ===== NAVBAR (desktop / tablet) ===== -->
 <nav class="navbar">
   <div class="container">
@@ -286,36 +244,6 @@
   <!-- end container -->
 </header>
 <!-- end page-header -->
-<section class="content-section accreditation-wrapper">
-  <div class="container">
-    <div class="accreditation-strip" aria-label="Labels qualité RenoGo">
-      <div class="accreditation-badge">
-        <figure>
-          <img src="images/badge-rge.svg" alt="Label RGE Qualibat détenu par RenoGo">
-        </figure>
-        <span>Rénovation RGE Qualibat</span>
-      </div>
-      <div class="accreditation-badge">
-        <figure>
-          <img src="images/badge-handibat.svg" alt="Certification d’accessibilité Handibat">
-        </figure>
-        <span>Conception Handibat</span>
-      </div>
-      <div class="accreditation-badge">
-        <figure>
-          <img src="images/badge-capeb.svg" alt="Adhésion CAPEB — artisans du bâtiment">
-        </figure>
-        <span>Partenaire CAPEB</span>
-      </div>
-      <div class="accreditation-badge">
-        <figure>
-          <img src="images/badge-eco-artisan.svg" alt="Mention Éco Artisan pour la performance énergétique">
-        </figure>
-        <span>Performance Éco Artisan</span>
-      </div>
-    </div>
-  </div>
-</section>
 <section class="content-section">
   <div class="container">
     <div class="row">
@@ -323,7 +251,7 @@
         <div class="icon-content">
           <figure><img src="images/icon01.png" alt="Proximité terrain"></figure>
           <h3>Experts de proximité</h3>
-          <small>Chefs de projet basés à Paris et en Normandie pour une réponse rapide à Caen, Rouen, Paris, La Défense ou Versailles.</small> <a href="#renovation-energetique">+</a> </div>
+          <small>Chefs de projet basés à Paris et en Normandie pour une réponse rapide à Caen, Rouen, Paris, La Défense ou Versailles.</small> <a href="#services-jardin">+</a> </div>
         <!-- end icon-content -->
       </div>
       <!-- end col-4 -->
@@ -331,7 +259,7 @@
         <div class="icon-content">
           <figure><img src="images/icon02.png" alt="Innovation durable"></figure>
           <h3>Durabilité & innovation</h3>
-          <small>Solutions bas carbone, domotique, HVAC et matériaux certifiés pour réduire vos charges et votre empreinte.</small> <a href="#fit-out-tertiaire">+</a> </div>
+          <small>Solutions bas carbone, domotique, HVAC et matériaux certifiés pour réduire vos charges et votre empreinte.</small> <a href="#services-electricite">+</a> </div>
         <!-- end icon-content -->
       </div>
       <!-- end col-4 -->
@@ -339,45 +267,7 @@
         <div class="icon-content">
           <figure><img src="images/icon03.png" alt="Suivi premium"></figure>
           <h3>Suivi clé en main</h3>
-          <small>Interlocuteur unique, reporting digital, maintenance préventive et service desk pour des chantiers sans surprises.</small> <a href="#salle-de-bains-pmr">+</a> </div>
-        <!-- end icon-content -->
-      </div>
-      <!-- end col-4 -->
-    </div>
-    <!-- end row -->
-  </div>
-  <!-- end container -->
-</section>
-<!-- end content-section -->
-<section class="content-section" id="services-prioritaires">
-  <div class="container">
-    <div class="section-title text-left">
-      <h6>SERVICES PRIORITAIRES</h6>
-      <h2>Interventions à forte valeur ajoutée</h2>
-    </div>
-    <!-- end section-title -->
-    <div class="row">
-      <div class="col-lg-4 col-md-6">
-        <div class="icon-content">
-          <figure><img src="images/icon05.png" alt="Design de cuisine sur mesure RenoGo"></figure>
-          <h3>Cuisine sur mesure</h3>
-          <small>Études ergonomiques, agencements premium, menuiseries sur mesure et équipements connectés pour cuisines familiales ou espaces showrooms.</small> <a href="#cuisine-sur-mesure">+</a> </div>
-        <!-- end icon-content -->
-      </div>
-      <!-- end col-4 -->
-      <div class="col-lg-4 col-md-6">
-        <div class="icon-content">
-          <figure><img src="images/icon04.png" alt="Salle de bains adaptée et accessible"></figure>
-          <h3>Salles de bains & PMR</h3>
-          <small>Création de suites bien-être, balnéo et salles de bains accessibles ERP ou logements locatifs conformes aux normes PMR.</small> <a href="#salle-de-bains-pmr">+</a> </div>
-        <!-- end icon-content -->
-      </div>
-      <!-- end col-4 -->
-      <div class="col-lg-4 col-md-6">
-        <div class="icon-content">
-          <figure><img src="images/icon02.png" alt="Audit énergétique et rénovation globale RenoGo"></figure>
-          <h3>Rénovation énergétique</h3>
-          <small>Audit global, isolation, HVAC, photovoltaïque et suivi des aides pour réduire la consommation de vos actifs résidentiels ou tertiaires.</small> <a href="#renovation-energetique">+</a> </div>
+          <small>Interlocuteur unique, reporting digital, maintenance préventive et service desk pour des chantiers sans surprises.</small> <a href="#accompagnement-renogo">+</a> </div>
         <!-- end icon-content -->
       </div>
       <!-- end col-4 -->
@@ -403,123 +293,6 @@
           </ul>
           <a href="contact.html" class="button">DEMANDER UN DIAGNOSTIC</a> </div>
         <!-- end services-list-box -->
-      </div>
-      <!-- end col-6 -->
-    </div>
-    <!-- end row -->
-  </div>
-  <!-- end container -->
-</section>
-<!-- end content-section -->
-<section class="content-section no-spacing" id="cuisine-sur-mesure">
-  <div class="container">
-    <div class="row align-items-center">
-      <div class="col-lg-6">
-        <figure class="side-image">
-          <img src="images/tab03.jpg" alt="Cuisine sur mesure réalisée par RenoGo">
-        </figure>
-      </div>
-      <!-- end col-6 -->
-      <div class="col-lg-6">
-        <div class="side-content">
-          <h6>CUISINES SUR MESURE</h6>
-          <h2>Optimiser chaque mètre carré de votre pièce de vie</h2>
-          <p>Nous concevons des cuisines sur mesure pensées pour votre quotidien : implantation en U, îlot central connecté, rangements invisibles et matériaux résistants aux fortes cadences. Nos architectes d’intérieur travaillent à partir de relevés 3D et d’ambiances personnalisées pour valoriser votre bien.</p>
-          <ul>
-            <li>Études ergonomiques, circulation et éclairage scénarisé pour cuisines familiales ou espaces de démonstration.</li>
-            <li>Fabrication sur mesure en ateliers normands : façades laquées, bois massif, plans de travail minéraux ou Dekton.</li>
-            <li>Intégration d’appareils premium, domotique, ventilation performante et protection anti-humidité.</li>
-            <li>Gestion complète : démolition, fluides, électricité, finitions et mise en service certifiée.</li>
-          </ul>
-          <a href="service-cuisine.html" class="button">VOIR LE DÉTAIL</a>
-        </div>
-        <!-- end side-content -->
-      </div>
-      <!-- end col-6 -->
-    </div>
-    <!-- end row -->
-  </div>
-  <!-- end container -->
-</section>
-<!-- end content-section -->
-<section class="content-section" id="salle-de-bains-pmr">
-  <div class="container">
-    <div class="row align-items-center">
-      <div class="col-lg-6 order-lg-2">
-        <figure class="side-image">
-          <img src="images/tab04.jpg" alt="Salle de bains PMR aménagée par RenoGo">
-        </figure>
-      </div>
-      <!-- end col-6 -->
-      <div class="col-lg-6 order-lg-1">
-        <div class="side-content">
-          <h6>SALLES DE BAINS & PMR</h6>
-          <h2>Confort hôtelier et conformité accessibilité</h2>
-          <p>Que ce soit pour un appartement locatif, une maison ou un établissement recevant du public, nous créons des salles de bains sécurisées, élégantes et conformes aux normes PMR. Chaque projet intègre une approche hygiène, ventilation et étanchéité pour garantir la pérennité des ouvrages.</p>
-          <ul>
-            <li>Douches à l’italienne avec receveurs extraplat, barres de maintien, sièges escamotables et robinetterie thermostatique.</li>
-            <li>Plans vasques adaptés, éclairage anti-éblouissement, miroirs chauffants et rangements accessibles.</li>
-            <li>Traitement anti-glisse, protections acoustiques, VMC hygroréglable et solutions anti-légionellose.</li>
-            <li>Accompagnement administratif : attestations accessibilité, DOE numérique et financement des aides ANAH.</li>
-          </ul>
-          <a href="service-salle-de-bains.html" class="button">DÉCOUVRIR L’OFFRE</a>
-        </div>
-        <!-- end side-content -->
-      </div>
-      <!-- end col-6 -->
-    </div>
-    <!-- end row -->
-  </div>
-  <!-- end container -->
-</section>
-<!-- end content-section -->
-<section class="content-section no-spacing" id="renovation-energetique" data-background="images/slide02.jpg">
-  <div class="container">
-    <div class="row justify-content-end">
-      <div class="col-lg-6 col-md-9">
-        <div class="services-list-box">
-          <h4>Rénovation énergétique globale</h4>
-          <p>Nos ingénieurs thermiques et conducteurs de travaux orchestrent des rénovations globales performantes pour diminuer vos consommations jusqu’à -45&nbsp;%. De la simulation énergétique à la pose des équipements, nous coordonnons un parcours de rénovation financé par les aides disponibles.</p>
-          <ul>
-            <li>Audit énergétique réglementaire, simulation STD et définition du scénario BBC compatible MaPrimeRénov’.</li>
-            <li>Isolation des enveloppes (ITE, combles, planchers), menuiseries, protections solaires et étanchéité à l’air.</li>
-            <li>Remplacement des systèmes CVC : pompes à chaleur, chaufferies gaz à condensation, ventilation double flux et GTB.</li>
-            <li>Suivi de performance post-travaux, télésuivi des consommations et maintenance préventive.</li>
-          </ul>
-          <a href="contact.html" class="button">PROGRAMMER UN AUDIT</a>
-        </div>
-        <!-- end services-list-box -->
-      </div>
-      <!-- end col-6 -->
-    </div>
-    <!-- end row -->
-  </div>
-  <!-- end container -->
-</section>
-<!-- end content-section -->
-<section class="content-section" id="fit-out-tertiaire">
-  <div class="container">
-    <div class="row align-items-center">
-      <div class="col-lg-6">
-        <div class="side-content">
-          <h6>FIT-OUT TERTIAIRE & COMMERCIAL</h6>
-          <h2>Des espaces professionnels performants et inspirants</h2>
-          <p>RenoGo aménage et rénove vos bureaux, commerces, cabinets médicaux ou hôtels avec une approche contractant général : design d’expérience utilisateur, normes de sécurité, continuité d’activité et efficacité énergétique.</p>
-          <ul>
-            <li>Audit d’occupation, space-planning, modélisation 3D et scénographie de vos parcours clients ou collaborateurs.</li>
-            <li>Mise aux normes incendie, accessibilité, SSI, CVC et réseaux faibles pour des locaux conformes et évolutifs.</li>
-            <li>Création d’espaces collaboratifs, phone-box, salles hybrides et corners retail clés en main.</li>
-            <li>Gestion de la continuité de service : planification nocturne/week-end, maintenance multitechnique et contrats FM.</li>
-          </ul>
-          <a href="contact.html" class="button">PLANIFIER UN FIT-OUT</a>
-        </div>
-        <!-- end side-content -->
-      </div>
-      <!-- end col-6 -->
-      <div class="col-lg-6">
-        <figure class="side-image">
-          <img src="images/slide01.jpg" alt="Aménagement de bureaux par RenoGo">
-        </figure>
       </div>
       <!-- end col-6 -->
     </div>


### PR DESCRIPTION
## Summary
- restore the home, services, and marketing subpages to the Oct 3 layout and copy, removing the weekend additions
- revert the compiled CSS/SCSS to the version that matches the earlier markup

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e29955bb40832e91e4727bcc4e76b6