### PR TITLE
Add responsive top support bar across pages

### DIFF
--- a/about-company.html
+++ b/about-company.html
@@ -135,6 +135,25 @@
     }
   }
   </script>
+<!-- ===== TOP CALL TO ACTION BAR ===== -->
+<div class="top-cta-bar">
+  <div class="container top-cta-container">
+    <div class="top-cta-item">
+      <i class="lni lni-timer" aria-hidden="true"></i>
+      <span>Disponible du lundi au vendredi 9h – 20h</span>
+    </div>
+    <a class="top-cta-item top-cta-link" href="https://renogo.atlassian.net/servicedesk/customer/portal/2" target="_blank" rel="noopener">
+      <i class="lni lni-life-ring" aria-hidden="true"></i>
+      <span>Assistance 24/7</span>
+    </a>
+    <a class="top-cta-item" href="tel:+33231974780" aria-label="Appeler RenoGo au 02 31 97 47 80">
+      <i class="lni lni-phone" aria-hidden="true"></i>
+      <span>02 31 97 47 80</span>
+    </a>
+  </div>
+</div>
+<!-- end top call to action bar -->
+
 <!-- ===== ASIDE (mobile drawer) ===== -->
 <aside class="side-widget">
   <div class="inner">

--- a/certificates.html
+++ b/certificates.html
@@ -54,7 +54,26 @@
 		</div>
 	</div>
 	<!-- end search-box -->
-	<aside class="side-widget">
+	<!-- ===== TOP CALL TO ACTION BAR ===== -->
+<div class="top-cta-bar">
+  <div class="container top-cta-container">
+    <div class="top-cta-item">
+      <i class="lni lni-timer" aria-hidden="true"></i>
+      <span>Disponible du lundi au vendredi 9h – 20h</span>
+    </div>
+    <a class="top-cta-item top-cta-link" href="https://renogo.atlassian.net/servicedesk/customer/portal/2" target="_blank" rel="noopener">
+      <i class="lni lni-life-ring" aria-hidden="true"></i>
+      <span>Assistance 24/7</span>
+    </a>
+    <a class="top-cta-item" href="tel:+33231974780" aria-label="Appeler RenoGo au 02 31 97 47 80">
+      <i class="lni lni-phone" aria-hidden="true"></i>
+      <span>02 31 97 47 80</span>
+    </a>
+  </div>
+</div>
+<!-- end top call to action bar -->
+
+<aside class="side-widget">
 	<div class="inner">
 			<div class="logo"> <a href="index.html"><img src="images/logo.png" alt="Image"></a> </div>
     <!-- end logo -->

--- a/contact.html
+++ b/contact.html
@@ -135,6 +135,25 @@
     }
   }
   </script>
+<!-- ===== TOP CALL TO ACTION BAR ===== -->
+<div class="top-cta-bar">
+  <div class="container top-cta-container">
+    <div class="top-cta-item">
+      <i class="lni lni-timer" aria-hidden="true"></i>
+      <span>Disponible du lundi au vendredi 9h – 20h</span>
+    </div>
+    <a class="top-cta-item top-cta-link" href="https://renogo.atlassian.net/servicedesk/customer/portal/2" target="_blank" rel="noopener">
+      <i class="lni lni-life-ring" aria-hidden="true"></i>
+      <span>Assistance 24/7</span>
+    </a>
+    <a class="top-cta-item" href="tel:+33231974780" aria-label="Appeler RenoGo au 02 31 97 47 80">
+      <i class="lni lni-phone" aria-hidden="true"></i>
+      <span>02 31 97 47 80</span>
+    </a>
+  </div>
+</div>
+<!-- end top call to action bar -->
+
 <!-- ===== ASIDE (mobile drawer) ===== -->
 <aside class="side-widget">
   <div class="inner">

--- a/core-values.html
+++ b/core-values.html
@@ -54,7 +54,26 @@
 		</div>
 	</div>
 	<!-- end search-box -->
-	<aside class="side-widget">
+	<!-- ===== TOP CALL TO ACTION BAR ===== -->
+<div class="top-cta-bar">
+  <div class="container top-cta-container">
+    <div class="top-cta-item">
+      <i class="lni lni-timer" aria-hidden="true"></i>
+      <span>Disponible du lundi au vendredi 9h – 20h</span>
+    </div>
+    <a class="top-cta-item top-cta-link" href="https://renogo.atlassian.net/servicedesk/customer/portal/2" target="_blank" rel="noopener">
+      <i class="lni lni-life-ring" aria-hidden="true"></i>
+      <span>Assistance 24/7</span>
+    </a>
+    <a class="top-cta-item" href="tel:+33231974780" aria-label="Appeler RenoGo au 02 31 97 47 80">
+      <i class="lni lni-phone" aria-hidden="true"></i>
+      <span>02 31 97 47 80</span>
+    </a>
+  </div>
+</div>
+<!-- end top call to action bar -->
+
+<aside class="side-widget">
 	<div class="inner">
 			<div class="logo"> <a href="index.html"><img src="images/logo.png" alt="Image"></a> </div>
     <!-- end logo -->

--- a/css/style.css
+++ b/css/style.css
@@ -672,6 +672,72 @@ a:hover {
   width: 100%;
 }
 
+/* TOP CTA BAR */
+.top-cta-bar {
+  background-color: #f58220;
+  color: #fff;
+  font-size: 15px;
+}
+
+.top-cta-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  padding: 0.5rem 0;
+  flex-wrap: wrap;
+  text-align: center;
+}
+
+.top-cta-item {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  color: inherit;
+  font-weight: 600;
+  text-decoration: none;
+  letter-spacing: 0.02em;
+}
+
+.top-cta-item i {
+  font-size: 1rem;
+}
+
+.top-cta-item span {
+  line-height: 1.4;
+}
+
+.top-cta-link {
+  text-decoration: none;
+}
+
+.top-cta-link:hover,
+.top-cta-link:focus {
+  color: #fff;
+}
+
+.top-cta-item:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
+}
+
+@media (max-width: 991px) {
+  .top-cta-container {
+    gap: 1rem;
+  }
+}
+
+@media (max-width: 575px) {
+  .top-cta-bar {
+    font-size: 14px;
+  }
+
+  .top-cta-item {
+    width: 100%;
+  }
+}
+
 /* NAVBAR */
 .navbar {
   width: 100%;

--- a/index.html
+++ b/index.html
@@ -135,6 +135,25 @@
     }
   }
   </script>
+<!-- ===== TOP CALL TO ACTION BAR ===== -->
+<div class="top-cta-bar">
+  <div class="container top-cta-container">
+    <div class="top-cta-item">
+      <i class="lni lni-timer" aria-hidden="true"></i>
+      <span>Disponible du lundi au vendredi 9h – 20h</span>
+    </div>
+    <a class="top-cta-item top-cta-link" href="https://renogo.atlassian.net/servicedesk/customer/portal/2" target="_blank" rel="noopener">
+      <i class="lni lni-life-ring" aria-hidden="true"></i>
+      <span>Assistance 24/7</span>
+    </a>
+    <a class="top-cta-item" href="tel:+33231974780" aria-label="Appeler RenoGo au 02 31 97 47 80">
+      <i class="lni lni-phone" aria-hidden="true"></i>
+      <span>02 31 97 47 80</span>
+    </a>
+  </div>
+</div>
+<!-- end top call to action bar -->
+
 <!-- ===== ASIDE (mobile drawer) ===== -->
 <aside class="side-widget">
   <div class="inner">

--- a/leadership.html
+++ b/leadership.html
@@ -54,7 +54,26 @@
 		</div>
 	</div>
 	<!-- end search-box -->
-	<aside class="side-widget">
+	<!-- ===== TOP CALL TO ACTION BAR ===== -->
+<div class="top-cta-bar">
+  <div class="container top-cta-container">
+    <div class="top-cta-item">
+      <i class="lni lni-timer" aria-hidden="true"></i>
+      <span>Disponible du lundi au vendredi 9h – 20h</span>
+    </div>
+    <a class="top-cta-item top-cta-link" href="https://renogo.atlassian.net/servicedesk/customer/portal/2" target="_blank" rel="noopener">
+      <i class="lni lni-life-ring" aria-hidden="true"></i>
+      <span>Assistance 24/7</span>
+    </a>
+    <a class="top-cta-item" href="tel:+33231974780" aria-label="Appeler RenoGo au 02 31 97 47 80">
+      <i class="lni lni-phone" aria-hidden="true"></i>
+      <span>02 31 97 47 80</span>
+    </a>
+  </div>
+</div>
+<!-- end top call to action bar -->
+
+<aside class="side-widget">
 	<div class="inner">
 			<div class="logo"> <a href="index.html"><img src="images/logo.png" alt="Image"></a> </div>
     <!-- end logo -->

--- a/news-sing.html
+++ b/news-sing.html
@@ -54,7 +54,26 @@
 		</div>
 	</div>
 	<!-- end search-box -->
-	<aside class="side-widget">
+	<!-- ===== TOP CALL TO ACTION BAR ===== -->
+<div class="top-cta-bar">
+  <div class="container top-cta-container">
+    <div class="top-cta-item">
+      <i class="lni lni-timer" aria-hidden="true"></i>
+      <span>Disponible du lundi au vendredi 9h – 20h</span>
+    </div>
+    <a class="top-cta-item top-cta-link" href="https://renogo.atlassian.net/servicedesk/customer/portal/2" target="_blank" rel="noopener">
+      <i class="lni lni-life-ring" aria-hidden="true"></i>
+      <span>Assistance 24/7</span>
+    </a>
+    <a class="top-cta-item" href="tel:+33231974780" aria-label="Appeler RenoGo au 02 31 97 47 80">
+      <i class="lni lni-phone" aria-hidden="true"></i>
+      <span>02 31 97 47 80</span>
+    </a>
+  </div>
+</div>
+<!-- end top call to action bar -->
+
+<aside class="side-widget">
 	<div class="inner">
 			<div class="logo"> <a href="index.html"><img src="images/logo.png" alt="Image"></a> </div>
     <!-- end logo -->

--- a/news.html
+++ b/news.html
@@ -135,6 +135,25 @@
     }
   }
   </script>
+<!-- ===== TOP CALL TO ACTION BAR ===== -->
+<div class="top-cta-bar">
+  <div class="container top-cta-container">
+    <div class="top-cta-item">
+      <i class="lni lni-timer" aria-hidden="true"></i>
+      <span>Disponible du lundi au vendredi 9h – 20h</span>
+    </div>
+    <a class="top-cta-item top-cta-link" href="https://renogo.atlassian.net/servicedesk/customer/portal/2" target="_blank" rel="noopener">
+      <i class="lni lni-life-ring" aria-hidden="true"></i>
+      <span>Assistance 24/7</span>
+    </a>
+    <a class="top-cta-item" href="tel:+33231974780" aria-label="Appeler RenoGo au 02 31 97 47 80">
+      <i class="lni lni-phone" aria-hidden="true"></i>
+      <span>02 31 97 47 80</span>
+    </a>
+  </div>
+</div>
+<!-- end top call to action bar -->
+
 <!-- ===== ASIDE (mobile drawer) ===== -->
 <aside class="side-widget">
   <div class="inner">

--- a/offices.html
+++ b/offices.html
@@ -54,7 +54,26 @@
 		</div>
 	</div>
 	<!-- end search-box -->
-	<aside class="side-widget">
+	<!-- ===== TOP CALL TO ACTION BAR ===== -->
+<div class="top-cta-bar">
+  <div class="container top-cta-container">
+    <div class="top-cta-item">
+      <i class="lni lni-timer" aria-hidden="true"></i>
+      <span>Disponible du lundi au vendredi 9h – 20h</span>
+    </div>
+    <a class="top-cta-item top-cta-link" href="https://renogo.atlassian.net/servicedesk/customer/portal/2" target="_blank" rel="noopener">
+      <i class="lni lni-life-ring" aria-hidden="true"></i>
+      <span>Assistance 24/7</span>
+    </a>
+    <a class="top-cta-item" href="tel:+33231974780" aria-label="Appeler RenoGo au 02 31 97 47 80">
+      <i class="lni lni-phone" aria-hidden="true"></i>
+      <span>02 31 97 47 80</span>
+    </a>
+  </div>
+</div>
+<!-- end top call to action bar -->
+
+<aside class="side-widget">
 	<div class="inner">
 			<div class="logo"> <a href="index.html"><img src="images/logo.png" alt="Image"></a> </div>
     <!-- end logo -->

--- a/our-history.html
+++ b/our-history.html
@@ -54,7 +54,26 @@
 		</div>
 	</div>
 	<!-- end search-box -->
-	<aside class="side-widget">
+	<!-- ===== TOP CALL TO ACTION BAR ===== -->
+<div class="top-cta-bar">
+  <div class="container top-cta-container">
+    <div class="top-cta-item">
+      <i class="lni lni-timer" aria-hidden="true"></i>
+      <span>Disponible du lundi au vendredi 9h – 20h</span>
+    </div>
+    <a class="top-cta-item top-cta-link" href="https://renogo.atlassian.net/servicedesk/customer/portal/2" target="_blank" rel="noopener">
+      <i class="lni lni-life-ring" aria-hidden="true"></i>
+      <span>Assistance 24/7</span>
+    </a>
+    <a class="top-cta-item" href="tel:+33231974780" aria-label="Appeler RenoGo au 02 31 97 47 80">
+      <i class="lni lni-phone" aria-hidden="true"></i>
+      <span>02 31 97 47 80</span>
+    </a>
+  </div>
+</div>
+<!-- end top call to action bar -->
+
+<aside class="side-widget">
 	<div class="inner">
 			<div class="logo"> <a href="index.html"><img src="images/logo.png" alt="Image"></a> </div>
     <!-- end logo -->

--- a/project-single.html
+++ b/project-single.html
@@ -54,7 +54,26 @@
 		</div>
 	</div>
 	<!-- end search-box -->
-	<aside class="side-widget">
+	<!-- ===== TOP CALL TO ACTION BAR ===== -->
+<div class="top-cta-bar">
+  <div class="container top-cta-container">
+    <div class="top-cta-item">
+      <i class="lni lni-timer" aria-hidden="true"></i>
+      <span>Disponible du lundi au vendredi 9h – 20h</span>
+    </div>
+    <a class="top-cta-item top-cta-link" href="https://renogo.atlassian.net/servicedesk/customer/portal/2" target="_blank" rel="noopener">
+      <i class="lni lni-life-ring" aria-hidden="true"></i>
+      <span>Assistance 24/7</span>
+    </a>
+    <a class="top-cta-item" href="tel:+33231974780" aria-label="Appeler RenoGo au 02 31 97 47 80">
+      <i class="lni lni-phone" aria-hidden="true"></i>
+      <span>02 31 97 47 80</span>
+    </a>
+  </div>
+</div>
+<!-- end top call to action bar -->
+
+<aside class="side-widget">
 	<div class="inner">
 			<div class="logo"> <a href="index.html"><img src="images/logo.png" alt="Image"></a> </div>
     <!-- end logo -->

--- a/projects.html
+++ b/projects.html
@@ -135,6 +135,25 @@
     }
   }
   </script>
+<!-- ===== TOP CALL TO ACTION BAR ===== -->
+<div class="top-cta-bar">
+  <div class="container top-cta-container">
+    <div class="top-cta-item">
+      <i class="lni lni-timer" aria-hidden="true"></i>
+      <span>Disponible du lundi au vendredi 9h – 20h</span>
+    </div>
+    <a class="top-cta-item top-cta-link" href="https://renogo.atlassian.net/servicedesk/customer/portal/2" target="_blank" rel="noopener">
+      <i class="lni lni-life-ring" aria-hidden="true"></i>
+      <span>Assistance 24/7</span>
+    </a>
+    <a class="top-cta-item" href="tel:+33231974780" aria-label="Appeler RenoGo au 02 31 97 47 80">
+      <i class="lni lni-phone" aria-hidden="true"></i>
+      <span>02 31 97 47 80</span>
+    </a>
+  </div>
+</div>
+<!-- end top call to action bar -->
+
 <!-- ===== ASIDE (mobile drawer) ===== -->
 <aside class="side-widget">
   <div class="inner">

--- a/service-cuisine.html
+++ b/service-cuisine.html
@@ -100,6 +100,25 @@
   }
   </script>
 </head>
+<!-- ===== TOP CALL TO ACTION BAR ===== -->
+<div class="top-cta-bar">
+  <div class="container top-cta-container">
+    <div class="top-cta-item">
+      <i class="lni lni-timer" aria-hidden="true"></i>
+      <span>Disponible du lundi au vendredi 9h – 20h</span>
+    </div>
+    <a class="top-cta-item top-cta-link" href="https://renogo.atlassian.net/servicedesk/customer/portal/2" target="_blank" rel="noopener">
+      <i class="lni lni-life-ring" aria-hidden="true"></i>
+      <span>Assistance 24/7</span>
+    </a>
+    <a class="top-cta-item" href="tel:+33231974780" aria-label="Appeler RenoGo au 02 31 97 47 80">
+      <i class="lni lni-phone" aria-hidden="true"></i>
+      <span>02 31 97 47 80</span>
+    </a>
+  </div>
+</div>
+<!-- end top call to action bar -->
+
 <!-- ===== ASIDE (mobile drawer) ===== -->
 <aside class="side-widget">
   <div class="inner">

--- a/service-salle-de-bains.html
+++ b/service-salle-de-bains.html
@@ -100,6 +100,25 @@
   }
   </script>
 </head>
+<!-- ===== TOP CALL TO ACTION BAR ===== -->
+<div class="top-cta-bar">
+  <div class="container top-cta-container">
+    <div class="top-cta-item">
+      <i class="lni lni-timer" aria-hidden="true"></i>
+      <span>Disponible du lundi au vendredi 9h – 20h</span>
+    </div>
+    <a class="top-cta-item top-cta-link" href="https://renogo.atlassian.net/servicedesk/customer/portal/2" target="_blank" rel="noopener">
+      <i class="lni lni-life-ring" aria-hidden="true"></i>
+      <span>Assistance 24/7</span>
+    </a>
+    <a class="top-cta-item" href="tel:+33231974780" aria-label="Appeler RenoGo au 02 31 97 47 80">
+      <i class="lni lni-phone" aria-hidden="true"></i>
+      <span>02 31 97 47 80</span>
+    </a>
+  </div>
+</div>
+<!-- end top call to action bar -->
+
 <!-- ===== ASIDE (mobile drawer) ===== -->
 <aside class="side-widget">
   <div class="inner">

--- a/services.html
+++ b/services.html
@@ -135,6 +135,25 @@
     }
   }
   </script>
+<!-- ===== TOP CALL TO ACTION BAR ===== -->
+<div class="top-cta-bar">
+  <div class="container top-cta-container">
+    <div class="top-cta-item">
+      <i class="lni lni-timer" aria-hidden="true"></i>
+      <span>Disponible du lundi au vendredi 9h – 20h</span>
+    </div>
+    <a class="top-cta-item top-cta-link" href="https://renogo.atlassian.net/servicedesk/customer/portal/2" target="_blank" rel="noopener">
+      <i class="lni lni-life-ring" aria-hidden="true"></i>
+      <span>Assistance 24/7</span>
+    </a>
+    <a class="top-cta-item" href="tel:+33231974780" aria-label="Appeler RenoGo au 02 31 97 47 80">
+      <i class="lni lni-phone" aria-hidden="true"></i>
+      <span>02 31 97 47 80</span>
+    </a>
+  </div>
+</div>
+<!-- end top call to action bar -->
+
 <!-- ===== ASIDE (mobile drawer) ===== -->
 <aside class="side-widget">
   <div class="inner">


### PR DESCRIPTION
## Summary
- add a reusable top call-to-action bar with assistance and phone links to every static page
- style the new bar for consistency with the site and ensure it adapts to smaller screens

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68e29c5a1058832e9adb11aea9c17d37